### PR TITLE
Prevent segfault after mmap failure

### DIFF
--- a/db.go
+++ b/db.go
@@ -332,7 +332,12 @@ func (db *DB) mmap(minsz int) error {
 
 	// Memory-map the data file as a byte slice.
 	if err := mmap(db, size); err != nil {
-		return err
+		// mmap failed; the system may have run out of space. Fallback to
+		// mapping the bare minimum needed for the current db size.
+		if err2 := mmap(db, db.datasz); err2 != nil {
+			panic(fmt.Sprintf("failed to revert db size after failed mmap: %v", err2))
+		}
+		return MmapError(err.Error())
 	}
 
 	// Save references to the meta pages.

--- a/errors.go
+++ b/errors.go
@@ -69,3 +69,10 @@ var (
 	// non-bucket key on an existing bucket key.
 	ErrIncompatibleValue = errors.New("incompatible value")
 )
+
+// MmapError represents an error resulting from a failed mmap call. Typically,
+// this error means that no further database writes will be possible. The most
+// common cause is insufficient disk space.
+type MmapError string
+
+func (e MmapError) Error() string { return string(e) }


### PR DESCRIPTION
Copied from https://github.com/boltdb/bolt/issues/706:

>Filling the disk with a bolt database causes a segfault on Windows. [This script](https://play.golang.org/p/4YJW_JUXDB) reproduces the bug (tested on Windows 10).
>
>stack trace:
>```
>unexpected fault address 0x7fff1040
>fatal error: fault
>[signal 0xc0000005 code=0x0 addr=0x7fff1040 pc=0x45b9e8]
> 
>goroutine 1 [running]:
>runtime.throw(0x4ecf03, 0x5)
>        C:/Go/src/runtime/panic.go:566 +0x9c fp=0xc0420d5c38 sp=0xc0420d5c18
>runtime.sigpanic()
>        C:/Go/src/runtime/signal_windows.go:164 +0x10b fp=0xc0420d5c68 sp=0xc0420d5c38
>github.com/boltdb/bolt.(*DB).meta(0xc04207e000, 0x1ec)
>        C:/Users/nebul/go/src/github.com/boltdb/bolt/db.go:811 +0x38 fp=0xc0420d5cc0 sp=0xc0420d5c68
>github.com/boltdb/bolt.(*Tx).rollback(0xc0420841c0)
>        C:/Users/nebul/go/src/github.com/boltdb/bolt/tx.go:255 +0x79 fp=0xc0420d5ce8 sp=0xc0420d5cc0
>github.com/boltdb/bolt.(*Tx).Commit(0xc0420841c0, 0x0, 0x0)
>        C:/Users/nebul/go/src/github.com/boltdb/bolt/tx.go:164 +0x8b2 fp=0xc0420d5e38 sp=0xc0420d5ce8
>github.com/boltdb/bolt.(*DB).Update(0xc04207e000, 0xc0420d5ec0, 0x0, 0x0)
>        C:/Users/nebul/go/src/github.com/boltdb/bolt/db.go:605 +0x114 fp=0xc0420d5e88 sp=0xc0420d5e38

I admit that I haven't tested whether bbolt suffers from the same bug, but it seems likely. I don't have immediate access to a Windows machine, so I'd be grateful to anyone willing to run the script linked above (after switching the import to bbolt, of course).

This PR implements the fix that I came up with for the issue. I submitted it to the original bolt repo (https://github.com/boltdb/bolt/pull/707) but got no response, so I went ahead and merged it into my own fork. We've been running it in production for a while now and it seems to work as intended.