### PR TITLE
Fix Windows flock/funlock race

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -4,14 +4,13 @@ package bbolt
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 	"time"
 	"unsafe"
 )
 
 // flock acquires an advisory lock on a file descriptor.
-func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+func flock(db *DB, exclusive bool, timeout time.Duration) error {
 	var t time.Time
 	if timeout != 0 {
 		t = time.Now()

--- a/bolt_unix_solaris.go
+++ b/bolt_unix_solaris.go
@@ -2,7 +2,6 @@ package bbolt
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 	"time"
 	"unsafe"
@@ -11,7 +10,7 @@ import (
 )
 
 // flock acquires an advisory lock on a file descriptor.
-func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
+func flock(db *DB, exclusive bool, timeout time.Duration) error {
 	var t time.Time
 	if timeout != 0 {
 		t = time.Now()

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -16,8 +16,6 @@ var (
 )
 
 const (
-	lockExt = ".lock"
-
 	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
 	flagLockExclusive       = 2
 	flagLockFailImmediately = 1
@@ -48,28 +46,24 @@ func fdatasync(db *DB) error {
 }
 
 // flock acquires an advisory lock on a file descriptor.
-func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) error {
-	// Create a separate lock file on windows because a process
-	// cannot share an exclusive lock on the same file. This is
-	// needed during Tx.WriteTo().
-	f, err := os.OpenFile(db.path+lockExt, os.O_CREATE, mode)
-	if err != nil {
-		return err
-	}
-	db.lockfile = f
-
+func flock(db *DB, exclusive bool, timeout time.Duration) error {
 	var t time.Time
 	if timeout != 0 {
 		t = time.Now()
 	}
-	fd := f.Fd()
 	var flag uint32 = flagLockFailImmediately
 	if exclusive {
 		flag |= flagLockExclusive
 	}
 	for {
-		// Attempt to obtain an exclusive lock.
-		err := lockFileEx(syscall.Handle(fd), flag, 0, 1, 0, &syscall.Overlapped{})
+		// Fix for https://github.com/etcd-io/bbolt/issues/121. Use byte-range
+		// -1..0 as the lock on the database file.
+		var m1 uint32 = (1 << 32) - 1 // -1 in a uint32
+		err := lockFileEx(syscall.Handle(db.file.Fd()), flag, 0, 1, 0, &syscall.Overlapped{
+			Offset:     m1,
+			OffsetHigh: m1,
+		})
+
 		if err == nil {
 			return nil
 		} else if err != errLockViolation {
@@ -88,9 +82,11 @@ func flock(db *DB, mode os.FileMode, exclusive bool, timeout time.Duration) erro
 
 // funlock releases an advisory lock on a file descriptor.
 func funlock(db *DB) error {
-	err := unlockFileEx(syscall.Handle(db.lockfile.Fd()), 0, 1, 0, &syscall.Overlapped{})
-	db.lockfile.Close()
-	os.Remove(db.path + lockExt)
+	var m1 uint32 = (1 << 32) - 1 // -1 in a uint32
+	err := unlockFileEx(syscall.Handle(db.file.Fd()), 0, 1, 0, &syscall.Overlapped{
+		Offset:     m1,
+		OffsetHigh: m1,
+	})
 	return err
 }
 

--- a/db.go
+++ b/db.go
@@ -105,8 +105,7 @@ type DB struct {
 
 	path     string
 	file     *os.File
-	lockfile *os.File // windows only
-	dataref  []byte   // mmap'ed readonly, write throws SEGV
+	dataref  []byte // mmap'ed readonly, write throws SEGV
 	data     *[maxMapSize]byte
 	datasz   int
 	filesz   int // current on disk file size
@@ -197,8 +196,7 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 	// if !options.ReadOnly.
 	// The database file is locked using the shared lock (more than one process may
 	// hold a lock at the same time) otherwise (options.ReadOnly is set).
-	if err := flock(db, mode, !db.readOnly, options.Timeout); err != nil {
-		db.lockfile = nil // make 'unused' happy. TODO: rework locks
+	if err := flock(db, !db.readOnly, options.Timeout); err != nil {
 		_ = db.close()
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Fixes https://github.com/etcd-io/bbolt/issues/121, and downstream https://github.com/docker/libnetwork/issues/1950. 

Using the test program from https://github.com/etcd-io/bbolt/issues/121:

```
package main

import (
	"fmt"
	"os"
	"sync"

	bolt "github.com/etcd-io/bbolt"
)

func main() {
	const instances = 30
	var wg sync.WaitGroup
	for instance := 0; instance < instances; instance++ {
		wg.Add(1)
		go opener(instance, &wg)

	}
	wg.Wait()
	fmt.Println("Success :)")
}

func opener(instance int, wg *sync.WaitGroup) {
	defer wg.Done()
	db, err := bolt.Open(`c:\bolt\test.db`, 0600, nil)
	if err != nil {
		panic(fmt.Sprintf("instance %d failed to open: %s", instance, err))
		os.Exit(-1)
	}
	db.Close()
}
```

Running it in two separate Windows, this now succeeds after running a significant amount of time without a panic. Pre this change, it would panic within the first few iterations.

`$lastExitCode=0;$i=0;while ($lastExitCode -eq 0) {$i++;echo $i;.\test.exe}`


```
Success :)
3128
Success :)
3129
Success :)
3130
Success :)
3131
Success :)
3132
Success :)
3133
Success :)
3134
Success :)
3135
Success :)
3136
Success :)
3137
Success :)
3138
Success :)
3139
Success :)
3140
```
etc.

@jstarks - Could you do a quick check please.

@dineshgovindasamy @msabansal @carlfischer1 @johnstep @mavenugo FYI.


