### PR TITLE
use mmap() to improve WRITE  performance   (issue #131)

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -539,7 +539,10 @@ func (tx *Tx) write() error {
 
 	// Ignore file sync if flag is set on DB.
 	if !tx.db.NoSync || IgnoreNoSync {
-		if err := fdatasync(tx.db); err != nil {
+		//if err := fdatasync(tx.db); err != nil {
+		//	return err
+		//}
+		if err := tx.db.mmapToDisk(); err != nil {
 			return err
 		}
 	}
@@ -576,7 +579,10 @@ func (tx *Tx) writeMeta() error {
 		return err
 	}
 	if !tx.db.NoSync || IgnoreNoSync {
-		if err := fdatasync(tx.db); err != nil {
+		//if err := fdatasync(tx.db); err != nil {
+		//	return err
+		//}
+		if err := tx.db.mmapToDisk(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
I use mmap()  to improve boltdb's write performance.
some simple benchmark as follow's link : 
https://github.com/CrocdileChan/benchboltdb

I bench many times.  The Performance increased by three to five times.
I hope it can be released in boltdb at next version.

Thanks a lot!