### PR TITLE
[do not merge] enable testing on go 1.12beta2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ go_import_path: go.etcd.io/bbolt
 sudo: false
 
 go:
-- 1.11
+- "1.11.x"
+- "1.12beta2"
 
 before_install:
 - go get -v honnef.co/go/tools/...


### PR DESCRIPTION
We've seen some SEGFAULTS on Go 1.12 on PowerPC ppc64le, originating from bbolt (at a quick glance). https://github.com/containerd/containerd/pull/2896#issuecomment-453788133

ppc64le is not being tested in this repository, but let's enable Go 1.12 to see if there's other failures

edit; ppc64le, not s390x 😅 