### PR TITLE
use segregated hmap to boost the freelist allocate and release performace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ GOLDFLAGS="-X main.branch $(BRANCH) -X main.commit $(COMMIT)"
 default: build
 
 race:
-	@go test -v -race -test.run="TestSimulate_(100op|1000op)"
+	@ARRAY_FREELIST=n go test -v -race -test.run="TestSimulate_(100op|1000op)"
+	@echo "array freelist test"
+	@ARRAY_FREELIST=y go test -v -race -test.run="TestSimulate_(100op|1000op)"
 
 fmt:
 	!(gofmt -l -s -d $(shell find . -name \*.go) | grep '[a-z]')
@@ -23,8 +25,14 @@ errcheck:
 	@errcheck -ignorepkg=bytes -ignore=os:Remove go.etcd.io/bbolt
 
 test:
-	go test -timeout 20m -v -coverprofile cover.out -covermode atomic
+	ARRAY_FREELIST=n go test -timeout 20m -v -coverprofile cover.out -covermode atomic
 	# Note: gets "program not an importable package" in out of path builds
-	go test -v ./cmd/bbolt
+	ARRAY_FREELIST=n go test -v ./cmd/bbolt
+
+	@echo "array freelist test"
+
+	@ARRAY_FREELIST=y go test -timeout 20m -v -coverprofile cover.out -covermode atomic
+	# Note: gets "program not an importable package" in out of path builds
+	@ARRAY_FREELIST=y go test -v ./cmd/bbolt
 
 .PHONY: race fmt errcheck test gosimple unused

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestTx_allocatePageStats(t *testing.T) {
-	f := newFreelist()
+	f := newTypedFreelist()
 	ids := []pgid{2, 3}
 	f.readIDs(ids)
 

--- a/db.go
+++ b/db.go
@@ -43,6 +43,15 @@ var defaultPageSize = os.Getpagesize()
 // The time elapsed between consecutive file locking attempts.
 const flockRetryTimeout = 50 * time.Millisecond
 
+type freelistType string
+
+const (
+	// ArrayType indicates backend freelist type is array
+	ArrayType = freelistType("array")
+	// HashMapType indicates backend freelist type is hashmap
+	HashMapType = freelistType("hashmap")
+)
+
 // DB represents a collection of buckets persisted to a file on disk.
 // All data access is performed through transactions which can be obtained through the DB.
 // All the functions on DB will return a ErrDatabaseNotOpen if accessed before Open() is called.
@@ -69,6 +78,12 @@ type DB struct {
 	// write performance under normal operation, but requires a full database
 	// re-sync during recovery.
 	NoFreelistSync bool
+
+	// FreelistType sets the backend freelist type. There are two options. Array which is simple but endures
+	// dramatic performance degradation if database is large and framentation in freelist is common.
+	// The alternative one is using hashmap, it is faster in almost all circumstances
+	// but it doesn't guarantee that it offers the smallest page id available. In normal case it is safe.
+	FreelistType freelistType
 
 	// When true, skips the truncate call when growing the database.
 	// Setting this to true is only safe on non-ext3/ext4 systems.
@@ -169,6 +184,7 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 	db.NoGrowSync = options.NoGrowSync
 	db.MmapFlags = options.MmapFlags
 	db.NoFreelistSync = options.NoFreelistSync
+	db.FreelistType = options.FreelistType
 
 	// Set default values for later DB operations.
 	db.MaxBatchSize = DefaultMaxBatchSize
@@ -283,7 +299,7 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 // concurrent accesses being made to the freelist.
 func (db *DB) loadFreelist() {
 	db.freelistLoad.Do(func() {
-		db.freelist = newFreelist()
+		db.freelist = newFreelist(db.FreelistType)
 		if !db.hasSyncedFreelist() {
 			// Reconstruct free list by scanning the DB.
 			db.freelist.readIDs(db.freepages())
@@ -291,7 +307,7 @@ func (db *DB) loadFreelist() {
 			// Read free list from freelist page.
 			db.freelist.read(db.page(db.meta().freelist))
 		}
-		db.stats.FreePageN = len(db.freelist.getFreePageIDs())
+		db.stats.FreePageN = db.freelist.free_count()
 	})
 }
 
@@ -1005,6 +1021,12 @@ type Options struct {
 	// under normal operation, but requires a full database re-sync during recovery.
 	NoFreelistSync bool
 
+	// FreelistType sets the backend freelist type. There are two options. Array which is simple but endures
+	// dramatic performance degradation if database is large and framentation in freelist is common.
+	// The alternative one is using hashmap, it is faster in almost all circumstances
+	// but it doesn't guarantee that it offers the smallest page id available. In normal case it is safe.
+	FreelistType freelistType
+
 	// Open database in read-only mode. Uses flock(..., LOCK_SH |LOCK_NB) to
 	// grab a shared lock (UNIX).
 	ReadOnly bool
@@ -1034,8 +1056,9 @@ type Options struct {
 // DefaultOptions represent the options used if nil options are passed into Open().
 // No timeout is used which will cause Bolt to wait indefinitely for a lock.
 var DefaultOptions = &Options{
-	Timeout:    0,
-	NoGrowSync: false,
+	Timeout:      0,
+	NoGrowSync:   false,
+	FreelistType: ArrayType,
 }
 
 // Stats represents statistics about the database.


### PR DESCRIPTION
In this pr, I use segregated bitmap to replace the original freeids allocating and releasing approach.
It is much faster than the original version, especially when the db size is large or the fragmentation in the db is large, we can gain 1000x faster performance.