### PR TITLE
remove excessive []byte(s) conversion

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -45,8 +45,8 @@ func TestNode_read_LeafPage(t *testing.T) {
 
 	// Write data for the nodes at the end.
 	data := (*[4096]byte)(unsafe.Pointer(&nodes[2]))
-	copy(data[:], []byte("barfooz"))
-	copy(data[7:], []byte("helloworldbye"))
+	copy(data[:], "barfooz")
+	copy(data[7:], "helloworldbye")
 
 	// Deserialize page into a leaf.
 	n := &node{}


### PR DESCRIPTION
`copy` permits using to mix `[]byte` and `string` arguments without
explicit conversion. I removed explicit conversion to make the code simpler.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>