### PR TITLE
bucket: Avoid repeat Cursor.seek on Bucket.CreateBucket()

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -189,7 +189,12 @@ func (b *Bucket) CreateBucket(key []byte) (*Bucket, error) {
 	// to be treated as a regular, non-inline bucket for the rest of the tx.
 	b.page = nil
 
-	return b.Bucket(key), nil
+	var child = b.openBucket(value)
+	if b.buckets != nil {
+		b.buckets[string(key)] = child
+	}
+
+	return child, nil
 }
 
 // CreateBucketIfNotExists creates a new bucket if it doesn't already exist and returns a reference to it.


### PR DESCRIPTION
in func CreateBucket() has kown the key posion, call b.Bucket(key) will duplicate call c.seek(key) to search the key postion. so we do not need to call b.Bucket(key).