### PR TITLE
add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go.etcd.io/bbolt
+
+go 1.12


### PR DESCRIPTION
Without this, testing with `GO111MODULE=on` gives the error:

```sh
$ go test -v -short .
go: creating new go.mod: module github.com/etcd-io/bbolt
# github.com/etcd-io/bbolt_test [github.com/etcd-io/bbolt.test]
./db_test.go:1613:22: undefined: bbolt.TestFreelistType
FAIL    github.com/etcd-io/bbolt [build failed]
```