### PR TITLE
Added ability to use custom sorts for a bucket & more documentation

### DIFF
--- a/bolt_test.go
+++ b/bolt_test.go
@@ -1,0 +1,38 @@
+package bbolt_test
+
+import (
+	"bytes"
+	"testing"
+
+	bolt "github.com/pixelrazor/bbolt"
+)
+
+// Ensure the usercan register their sort functions
+func Test_RegisterSort(t *testing.T) {
+	mysort := func(a, b []byte) int {
+		return 0
+	}
+	if err := bolt.RegisterSort(mysort); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that registering can't accidentally override a function with the same hash
+func Test_RegisterSort_Duplicate(t *testing.T) {
+	mysort := func(a, b []byte) int {
+		return 0
+	}
+	if err := bolt.RegisterSort(mysort); err != nil {
+		t.Fatal(err)
+	}
+	if err := bolt.RegisterSort(mysort); err == nil {
+		t.Fail()
+	}
+}
+
+// Ensure the user can't register the default sort (bytes.Compare)
+func Test_RegisterSort_Bytes(t *testing.T) {
+	if err := bolt.RegisterSort(bytes.Compare); err == nil {
+		t.Fail()
+	}
+}

--- a/bolt_test.go
+++ b/bolt_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	bolt "github.com/pixelrazor/bbolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 // Ensure the usercan register their sort functions

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	bolt "github.com/pixelrazor/bbolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 // Ensure that a bucket that gets a non-existent key returns nil.

--- a/cursor.go
+++ b/cursor.go
@@ -1,7 +1,6 @@
 package bbolt
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 )
@@ -270,7 +269,7 @@ func (c *Cursor) searchNode(key []byte, n *node) {
 	index := sort.Search(len(n.inodes), func(i int) bool {
 		// TODO(benbjohnson): Optimize this range search. It's a bit hacky right now.
 		// sort.Search() finds the lowest index where f() != -1 but we need the highest index.
-		ret := bytes.Compare(n.inodes[i].key, key)
+		ret := sorts[c.bucket.sort](n.inodes[i].key, key)
 		if ret == 0 {
 			exact = true
 		}
@@ -293,7 +292,7 @@ func (c *Cursor) searchPage(key []byte, p *page) {
 	index := sort.Search(int(p.count), func(i int) bool {
 		// TODO(benbjohnson): Optimize this range search. It's a bit hacky right now.
 		// sort.Search() finds the lowest index where f() != -1 but we need the highest index.
-		ret := bytes.Compare(inodes[i].key(), key)
+		ret := sorts[c.bucket.sort](inodes[i].key(), key)
 		if ret == 0 {
 			exact = true
 		}
@@ -316,7 +315,7 @@ func (c *Cursor) nsearch(key []byte) {
 	// If we have a node then search its inodes.
 	if n != nil {
 		index := sort.Search(len(n.inodes), func(i int) bool {
-			return bytes.Compare(n.inodes[i].key, key) != -1
+			return sorts[c.bucket.sort](n.inodes[i].key, key) != -1
 		})
 		e.index = index
 		return
@@ -325,7 +324,7 @@ func (c *Cursor) nsearch(key []byte) {
 	// If we have a page then search its leaf elements.
 	inodes := p.leafPageElements()
 	index := sort.Search(int(p.count), func(i int) bool {
-		return bytes.Compare(inodes[i].key(), key) != -1
+		return sorts[c.bucket.sort](inodes[i].key(), key) != -1
 	})
 	e.index = index
 }

--- a/db.go
+++ b/db.go
@@ -979,6 +979,7 @@ func (db *DB) grow(sz int) error {
 	return nil
 }
 
+// IsReadOnly returns true if the database was opened without write permissions
 func (db *DB) IsReadOnly() bool {
 	return db.readOnly
 }

--- a/errors.go
+++ b/errors.go
@@ -68,4 +68,8 @@ var (
 	// on an existing non-bucket key or when trying to create or delete a
 	// non-bucket key on an existing bucket key.
 	ErrIncompatibleValue = errors.New("incompatible value")
+
+	// ErrUnregisteredSort is returned when trying to create a bucket using an unregistered
+	// sort function or by trying to open a bucket without having its sort function registered
+	ErrUnregisteredSort = errors.New("sort is unregistered")
 )

--- a/node.go
+++ b/node.go
@@ -79,7 +79,7 @@ func (n *node) childAt(index int) *node {
 
 // childIndex returns the index of a given child node.
 func (n *node) childIndex(child *node) int {
-	index := sort.Search(len(n.inodes), func(i int) bool { return bytes.Compare(n.inodes[i].key, child.key) != -1 })
+	index := sort.Search(len(n.inodes), func(i int) bool { return sorts[n.bucket.sort](n.inodes[i].key, child.key) != -1 })
 	return index
 }
 
@@ -123,7 +123,7 @@ func (n *node) put(oldKey, newKey, value []byte, pgid pgid, flags uint32) {
 	}
 
 	// Find insertion index.
-	index := sort.Search(len(n.inodes), func(i int) bool { return bytes.Compare(n.inodes[i].key, oldKey) != -1 })
+	index := sort.Search(len(n.inodes), func(i int) bool { return sorts[n.bucket.sort](n.inodes[i].key, oldKey) != -1 })
 
 	// Add capacity and shift nodes if we don't have an exact match and need to insert.
 	exact := (len(n.inodes) > 0 && index < len(n.inodes) && bytes.Equal(n.inodes[index].key, oldKey))
@@ -143,7 +143,7 @@ func (n *node) put(oldKey, newKey, value []byte, pgid pgid, flags uint32) {
 // del removes a key from the node.
 func (n *node) del(key []byte) {
 	// Find index of key.
-	index := sort.Search(len(n.inodes), func(i int) bool { return bytes.Compare(n.inodes[i].key, key) != -1 })
+	index := sort.Search(len(n.inodes), func(i int) bool { return sorts[n.bucket.sort](n.inodes[i].key, key) != -1 })
 
 	// Exit if the key isn't found.
 	if index >= len(n.inodes) || !bytes.Equal(n.inodes[index].key, key) {
@@ -587,9 +587,11 @@ func (n *node) dump() {
 
 type nodes []*node
 
-func (s nodes) Len() int           { return len(s) }
-func (s nodes) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s nodes) Less(i, j int) bool { return bytes.Compare(s[i].inodes[0].key, s[j].inodes[0].key) == -1 }
+func (s nodes) Len() int      { return len(s) }
+func (s nodes) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s nodes) Less(i, j int) bool {
+	return sorts[s[i].bucket.sort](s[i].inodes[0].key, s[j].inodes[0].key) == -1
+}
 
 // inode represents an internal node inside of a node.
 // It can be used to point to elements in a page or point

--- a/node_test.go
+++ b/node_test.go
@@ -7,7 +7,7 @@ import (
 
 // Ensure that a node can insert a key/value.
 func TestNode_put(t *testing.T) {
-	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{meta: &meta{pgid: 1}}}}
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{bucket: &bucket{}, tx: &Tx{meta: &meta{pgid: 1}}}}
 	n.put([]byte("baz"), []byte("baz"), []byte("2"), 0, 0)
 	n.put([]byte("foo"), []byte("foo"), []byte("0"), 0, 0)
 	n.put([]byte("bar"), []byte("bar"), []byte("1"), 0, 0)
@@ -70,7 +70,7 @@ func TestNode_read_LeafPage(t *testing.T) {
 // Ensure that a node can serialize into a leaf page.
 func TestNode_write_LeafPage(t *testing.T) {
 	// Create a node.
-	n := &node{isLeaf: true, inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n := &node{isLeaf: true, inodes: make(inodes, 0), bucket: &Bucket{bucket: &bucket{}, tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
 	n.put([]byte("susy"), []byte("susy"), []byte("que"), 0, 0)
 	n.put([]byte("ricki"), []byte("ricki"), []byte("lake"), 0, 0)
 	n.put([]byte("john"), []byte("john"), []byte("johnson"), 0, 0)
@@ -102,7 +102,7 @@ func TestNode_write_LeafPage(t *testing.T) {
 // Ensure that a node can split into appropriate subgroups.
 func TestNode_split(t *testing.T) {
 	// Create a node.
-	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{bucket: &bucket{}, tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
 	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
 	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
 	n.put([]byte("00000003"), []byte("00000003"), []byte("0123456701234567"), 0, 0)
@@ -127,7 +127,7 @@ func TestNode_split(t *testing.T) {
 // Ensure that a page with the minimum number of inodes just returns a single node.
 func TestNode_split_MinKeys(t *testing.T) {
 	// Create a node.
-	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{bucket: &bucket{}, tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
 	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
 	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
 
@@ -141,7 +141,7 @@ func TestNode_split_MinKeys(t *testing.T) {
 // Ensure that a node that has keys that all fit on a page just returns one leaf.
 func TestNode_split_SinglePage(t *testing.T) {
 	// Create a node.
-	n := &node{inodes: make(inodes, 0), bucket: &Bucket{tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
+	n := &node{inodes: make(inodes, 0), bucket: &Bucket{bucket: &bucket{}, tx: &Tx{db: &DB{}, meta: &meta{pgid: 1}}}}
 	n.put([]byte("00000001"), []byte("00000001"), []byte("0123456701234567"), 0, 0)
 	n.put([]byte("00000002"), []byte("00000002"), []byte("0123456701234567"), 0, 0)
 	n.put([]byte("00000003"), []byte("00000003"), []byte("0123456701234567"), 0, 0)

--- a/tx.go
+++ b/tx.go
@@ -108,6 +108,14 @@ func (tx *Tx) CreateBucket(name []byte) (*Bucket, error) {
 	return tx.root.CreateBucket(name)
 }
 
+// CreateBucketWithSort creates a new bucket at the given key and sort function and returns the new bucket.
+// Returns an error if the key already exists, if the bucket name is blank, if the sort function is
+// unregistered, or if the bucket name is too long.
+// The bucket instance is only valid for the lifetime of the transaction.
+func (tx *Tx) CreateBucketWithSort(name []byte, sort func(a, b []byte) int) (*Bucket, error) {
+	return tx.root.CreateBucketWithSort(name, sort)
+}
+
 // CreateBucketIfNotExists creates a new bucket if it doesn't already exist.
 // Returns an error if the bucket name is blank, or if the bucket name is too long.
 // The bucket instance is only valid for the lifetime of the transaction.

--- a/tx_test.go
+++ b/tx_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	bolt "go.etcd.io/bbolt"
+	bolt "github.com/pixelrazor/bbolt"
 )
 
 // TestTx_Check_ReadOnly tests consistency checking on a ReadOnly database.
@@ -247,6 +247,75 @@ func TestTx_CreateBucket(t *testing.T) {
 	if err := db.View(func(tx *bolt.Tx) error {
 		if tx.Bucket([]byte("widgets")) == nil {
 			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can be created with a provided sort and retrieved.
+func TestTx_CreateBucket_WithSort(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	reverse := func(a, b []byte) int {
+		switch bytes.Compare(a, b) {
+		case 1:
+			return -1
+		case -1:
+			return 1
+		default:
+			return 0
+		}
+	}
+	bolt.RegisterSort(reverse)
+
+	// Create a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketWithSort([]byte("widgets"), reverse)
+		if err != nil {
+			t.Fatal(err)
+		} else if b == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the bucket through a separate transaction.
+	if err := db.View(func(tx *bolt.Tx) error {
+		if tx.Bucket([]byte("widgets")) == nil {
+			t.Fatal("expected bucket")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Ensure that a bucket can't be created with an unregistered sort.
+func TestTx_CreateBucket_WithSort_Unregistered(t *testing.T) {
+	db := MustOpenDB()
+	defer db.MustClose()
+
+	reverse := func(a, b []byte) int {
+		switch bytes.Compare(a, b) {
+		case 1:
+			return -1
+		case -1:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	// Create a bucket.
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketWithSort([]byte("widgets"), reverse)
+		if err != bolt.ErrUnregisteredSort {
+			t.Fatal(err)
 		}
 		return nil
 	}); err != nil {

--- a/tx_test.go
+++ b/tx_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"testing"
 
-	bolt "github.com/pixelrazor/bbolt"
+	bolt "go.etcd.io/bbolt"
 )
 
 // TestTx_Check_ReadOnly tests consistency checking on a ReadOnly database.


### PR DESCRIPTION
Users can now register their sort functions and use them when creating a bucket. The hash of the function name (obtained via reflect) is stored in the bucket header. Attempting to open a bucket that doesn't have the proper function registered will return nil.

#156 