### PR TITLE
db.Path() resolves to db.file.Name()

### DIFF
--- a/db.go
+++ b/db.go
@@ -206,12 +206,12 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 	}
 
 	// Open data file and separate sync handler for metadata writes.
-	db.path = path
 	var err error
-	if db.file, err = db.openFile(db.path, flag|os.O_CREATE, mode); err != nil {
+	if db.file, err = db.openFile(path, flag|os.O_CREATE, mode); err != nil {
 		_ = db.close()
 		return nil, err
 	}
+	db.path = db.file.Name()
 
 	// Lock file so that other processes using Bolt in read-write mode cannot
 	// use the database  at the same time. This would cause corruption since


### PR DESCRIPTION
When using a custom `OpenFile` function during tests it is convenient to use a function which creates temporary files for the Bolt database, which are then unlinked during test teardown.

Consider the following example, where for the `name` of the database when calling `bolt.Open` we use an empty name and a custom `OpenFile` function.

The custom `OpenFile` function will create a temporary file, which name we don't know upfront, so a call to `db.Path()` would have to resolve the underlying file's path.

The proposed patch fixes this by making `DB.Path()` resolve to `db.file.Path()`.

Below is an example test case where using a custom `OpenFile` creates a temporary file for the Bolt database.

```go
// dbOpenFile is a wrapper around ioutil.TempFile.
// dbOpenFile is used to open the Bolt database file. By default Bolt will use
// os.OpenFile in order to open the db file.
// During tests we will use a random-generated temporary file, which will be
// unlinked during teardown.
func dbOpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
	return ioutil.TempFile("", "some-name.*.db")
}

// setupDb creates a new Bolt database backed by a temporary file.
// Returns a *bolt.DB and a teardown function.
func setupDb(t *testing.T) (*bolt.DB, func()) {
	dbOptions := &bolt.Options{
		Timeout:  1 * time.Second,
		OpenFile: dbOpenFile,
	}

	// ioutil.TempFile by default uses `os.O_RDWR|os.O_CREATE|os.O_EXCL` flags and
	// sets persmissions to `0600`, so we are good here.
	// The name will be automatically generated by `dbOpenFile` function, so we can
	// pass an empty database name here as well.
	db, err := bolt.Open("", 0600, dbOptions)
	if err != nil {
		t.Fatalf("Cannot open database: %s", err)
	}

	teardown := func() {
		dbPath := db.Path()
		if err := db.Close(); err != nil {
			t.Errorf("Cannot close database file %s: %s\n", dbPath, err)
		}
		if err := os.Remove(dbPath); err != nil {
			t.Errorf("Cannot unlink database file %s: %s\n", dbPath, err)
		}
	}

	return db, teardown
}
```