### PR TITLE
Mark db as unusable if mmap fails

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -69,3 +69,10 @@ var (
 	// non-bucket key on an existing bucket key.
 	ErrIncompatibleValue = errors.New("incompatible value")
 )
+
+// MmapError represents an error resulting from a failed mmap call. Typically,
+// this error means that no further database writes will be possible. The most
+// common cause is insufficient disk space.
+type MmapError string
+
+func (e MmapError) Error() string { return string(e) }

--- a/tx.go
+++ b/tx.go
@@ -274,6 +274,12 @@ func (tx *Tx) rollback() {
 	if tx.db == nil {
 		return
 	}
+	// If the transaction failed due to mmap, rollback is futile.
+	if tx.db.mmapErr != nil {
+		tx.close()
+		return
+	}
+
 	if tx.writable {
 		tx.db.freelist.rollback(tx.meta.txid)
 		if !tx.db.hasSyncedFreelist() {


### PR DESCRIPTION
If an error is ever encountered when `mmap`-ing the db, mark the db as unusable by setting `mmapErr`. Calls to `View`/`Update`/etc. will thereafter return the `mmap` error. The error uses a special type so that callers can recognize and react to `mmap` errors specifically.