### PR TITLE
Fix misusage of t.Fatal() in test functions

### DIFF
--- a/simulation_test.go
+++ b/simulation_test.go
@@ -88,7 +88,6 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 				// Start transaction.
 				tx, err := db.Begin(writable)
 				if err != nil {
-
 				  errCh <- fmt.Errorf("error tx begin: %v", err)
 					return
 				}

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -88,7 +88,7 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 				// Start transaction.
 				tx, err := db.Begin(writable)
 				if err != nil {
-				  errCh <- fmt.Errorf("error tx begin: %v", err)
+					errCh <- fmt.Errorf("error tx begin: %v", err)
 					return
 				}
 


### PR DESCRIPTION
Fixes #165 

***Description***
In 5 test functions, `t.Fatal()` is called in child goroutines, instead of in the test goroutine. This is a common misusage of `t.Fatal()`, because `t.Fatal()` calls `t.FailNow()`:
[FailNow must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test. Calling FailNow does not stop those other goroutines.](https://golang.org/pkg/testing/#B.FailNow)

***How they are fixed***
A channel is used to receive error. This channel has 1 buffer to make the send not blocking. If there are multiple child goroutines, I use `select` to make sure no goroutines will be blocked.