### PR TITLE
fix panic on install on unix systems

### DIFF
--- a/bolt_unix_aix.go
+++ b/bolt_unix_aix.go
@@ -1,3 +1,5 @@
+// +build aix
+
 package bbolt
 
 import (


### PR DESCRIPTION
This a fix for issue #195 

We need to build the unix_aix.go file only on aix systems right now it was building for all systems and that creates a few different panics on install about methods like flock being redeclared. 