### PR TITLE
Fix unexpected delete bucket error: "delete bucket: incompatible value"

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -228,7 +228,7 @@ func (b *Bucket) DeleteBucket(key []byte) error {
 	// Recursively delete all child buckets.
 	child := b.Bucket(key)
 	err := child.ForEach(func(k, v []byte) error {
-		if v == nil {
+		if _, _, childFlags := child.Cursor().seek(k); (childFlags & bucketLeafFlag) != 0 {
 			if err := child.DeleteBucket(k); err != nil {
 				return fmt.Errorf("delete bucket: %s", err)
 			}


### PR DESCRIPTION
This is a fix for issue #208.
The fix created not by me, but taken from here: https://github.com/ufoot/bolt/commit/77ae42bd2d0613614b77ffb22f2485153560fffd