### PR TITLE
modify freelist_hmap/hashmapGetFreePageIDs with better performance

### DIFF
--- a/freelist_hmap.go
+++ b/freelist_hmap.go
@@ -76,12 +76,21 @@ func (f *freelist) hashmapGetFreePageIDs() []pgid {
 	}
 
 	m := make([]pgid, 0, count)
-	for start, size := range f.forwardMap {
-		for i := 0; i < int(size); i++ {
-			m = append(m, start+pgid(i))
+
+	keys := make([]pgid, 0, len(f.forwardMap))
+	for k, _ := range f.forwardMap {
+		keys = append(keys, k)
+	}
+	sort.Sort(pgids(keys))
+
+	for _, start := range keys {
+		size, ok := f.forwardMap[start]
+		if (ok) {
+			for i := 0; i < int(size); i++ {
+				m = append(m, start+pgid(i))
+			}
 		}
 	}
-	sort.Sort(pgids(m))
 
 	return m
 }

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -443,7 +443,7 @@ func Test_freelist_hashmapGetFreePageIDs(t *testing.T) {
 	res := f.hashmapGetFreePageIDs()
 
 	if !sort.SliceIsSorted(res, func(i, j int) bool { return res[i] < res[j] }) {
-		panic("pgids not sorted")
+		t.Fatalf("pgids not sorted")
 	}
 }
 

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -423,6 +423,28 @@ func Test_freelist_mergeWithExist(t *testing.T) {
 	}
 }
 
+func Test_freelist_hashmapGetFreePageIDs(t *testing.T) {
+	f := newTestFreelist()
+	if f.freelistType == FreelistArrayType {
+		t.Skip()
+	}
+
+	N := 10000
+	val_len := 1000
+	fm := make(map[pgid]uint64)
+	for i := 0; i < N * val_len;  i += val_len{
+		fm[pgid(i)] = uint64(val_len)
+	}
+
+	f.forwardMap = fm
+	res := f.hashmapGetFreePageIDs()
+
+	if !sort.SliceIsSorted(res, func(i, j int) bool { return res[i] < res[j] }) {
+		panic("pgids not sorted")
+	}
+}
+
+
 // newTestFreelist get the freelist type from env and initial the freelist
 func newTestFreelist() *freelist {
 	freelistType := FreelistArrayType

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -429,11 +429,14 @@ func Test_freelist_hashmapGetFreePageIDs(t *testing.T) {
 		t.Skip()
 	}
 
-	N := 10000
-	val_len := 1000
+	N := int32(100000)
 	fm := make(map[pgid]uint64)
-	for i := 0; i < N * val_len;  i += val_len{
-		fm[pgid(i)] = uint64(val_len)
+	i := int32(0)
+	val := int32(0)
+	for i = 0; i < N;  {
+		val = rand.Int31n(1000)
+		fm[pgid(i)] = uint64(val)
+		i += val
 	}
 
 	f.forwardMap = fm


### PR DESCRIPTION
Since forwardMap key is the start point, value is the length starting with the key, then we just sort the key to make the whole array sorted instead of sorting the whole array.

This is my performance test compared with these two algorithms:

1. N: is the number of forwardMap key
2. val: is the value of each key
3. time_used_origin: is the time used of the origin function
4. time_used_new: is the time used of the improved function

| N      | val |    time_used_origin     | time_used_new |  
| ---      | ---       | ---      | ---       |
| 10000 | 1       | 2.301202ms | 2.614463ms       |
| 10000     | 10      | 18.204936ms |    2.942327ms   |
| 10000     | 100      | 164.167666ms |    7.275755ms   |
| 10000     | 1000      | 1.71088519s |    115.790789ms   |
| 10000     | 10000      | 19.85861009s |    1.625219654s   |