### PR TITLE
change freelist_hmap/hashmapGetFreePageIDs with better performance

### DIFF
--- a/freelist_hmap.go
+++ b/freelist_hmap.go
@@ -76,12 +76,21 @@ func (f *freelist) hashmapGetFreePageIDs() []pgid {
 	}
 
 	m := make([]pgid, 0, count)
-	for start, size := range f.forwardMap {
-		for i := 0; i < int(size); i++ {
-			m = append(m, start+pgid(i))
+
+	keys := make([]pgid, 0, len(f.forwardMap))
+	for k, _ := range f.forwardMap {
+		keys = append(keys, k)
+	}
+	sort.Sort(pgids(keys))
+
+	for _, start := range keys {
+		size, ok := f.forwardMap[start]
+		if (ok) {
+			for i := 0; i < int(size); i++ {
+				m = append(m, start+pgid(i))
+			}
 		}
 	}
-	sort.Sort(pgids(m))
 
 	return m
 }

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -432,3 +432,29 @@ func newTestFreelist() *freelist {
 
 	return newFreelist(freelistType)
 }
+
+
+func Test_freelist_hashmapGetFreePageIDs(t *testing.T) {
+	f := newTestFreelist()
+	if f.freelistType == FreelistArrayType {
+		t.Skip()
+	}
+
+	N := int32(100000)
+	fm := make(map[pgid]uint64)
+	i := int32(0)
+	val := int32(0)
+	for i = 0; i < N;  {
+		val = rand.Int31n(1000)
+		fm[pgid(i)] = uint64(val)
+		i += val
+	}
+
+	f.forwardMap = fm
+	res := f.hashmapGetFreePageIDs()
+
+	if !sort.SliceIsSorted(res, func(i, j int) bool { return res[i] < res[j] }) {
+		t.Fatalf("pgids not sorted")
+	}
+}
+


### PR DESCRIPTION
Since forwardMap key is the start point, value is the length starting with the key, then we just sort the key to make the whole array sorted instead of sorting the whole array.

This is my performance test compared with these two algorithms:

1. N: is the number of forwardMap key
2. val: is the value of each key
3. time_used_origin: is the time used of the origin function
4. time_used_new: is the time used of the improved function

| N      | val |    time_used_origin     | time_used_new |  
| ---      | ---       | ---      | ---       |
| 10000 | 1       | 2.301202ms | 2.614463ms       |
| 10000     | 10      | 18.204936ms |    2.942327ms   |
| 10000     | 100      | 164.167666ms |    7.275755ms   |
| 10000     | 1000      | 1.71088519s |    115.790789ms   |
| 10000     | 10000      | 19.85861009s |    1.625219654s   |


```
func main() {
	N := int32(10000)
	fm := make(map[pgid]uint64)
	i := int32(0)
	val := int32(0)
	for i = 0; i < N;  {
		val = rand.Int31n(1000)
		fm[pgid(i)] = uint64(val)
		i += val
	}

	f := freelist{
		forwardMap: fm,
	}
	start := time.Now()
	f.hashmapGetFreePageIDs()
	end := time.Now()
	fmt.Printf("origin time:%v\n", end.Sub(start))

	start = time.Now()
	res := f.newHashmapGetFreePageIDs()
	end = time.Now()
	fmt.Printf("new time:%v\n", end.Sub(start))


	if !sort.SliceIsSorted(res, func(i, j int) bool { return res[i] < res[j] }) {
		panic("pgids not sorted")
	}
}
```

based on the above testing program, when changing N, got the following result compared with two functions

| N     | time_used_origin | time_used_new |
| ---      | ---       | ---      | 
| 100 |    71.608µs    |  9.022µs |
| 1000 |    226.745µs    |  19.359µs |
| 10000 |    1.290836ms    |  77.194µs |
| 100000 |    15.973611ms    |  777.995µs |
| 1000000 |    160.912048ms    |  5.714576ms |
| 10000000 |    1.789962277s    |  99.443407ms |






