### PR TITLE
Reimplement DB.freePages() for clarity

### DIFF
--- a/freelist_test.go
+++ b/freelist_test.go
@@ -96,7 +96,7 @@ func TestFreelist_release(t *testing.T) {
 		{
 			title:    "Single pending #9",
 			pagesIn:  []testPage{{id: 3, n: 1, allocTxn: 100, freeTxn: 200}},
-			txidSets: [][]txid{{100}},
+			txidSets: [][]txid{{100, 199}},
 			wantFree: []pgid{},
 		},
 		{
@@ -145,7 +145,7 @@ func TestFreelist_release(t *testing.T) {
 			wantFree: []pgid{3, 4},
 		},
 		{
-			title: "Multiple pending",
+			title: "Multiple pending #1",
 			pagesIn: []testPage{
 				{id: 3, n: 1, allocTxn: 100, freeTxn: 200},
 				{id: 4, n: 1, allocTxn: 100, freeTxn: 125},
@@ -159,6 +159,22 @@ func TestFreelist_release(t *testing.T) {
 				{50, 149, 151, 300},
 			},
 			wantFree: []pgid{4, 9, 10},
+		},
+		{
+			title: "Multiple pending #2",
+			pagesIn: []testPage{
+				{id: 3, n: 1, allocTxn: 100, freeTxn: 200},
+				{id: 4, n: 1, allocTxn: 100, freeTxn: 250},
+				{id: 5, n: 1, allocTxn: 125, freeTxn: 200},
+				{id: 6, n: 1, allocTxn: 125, freeTxn: 250},
+				{id: 7, n: 2, allocTxn: 150, freeTxn: 200},
+				{id: 9, n: 2, allocTxn: 175, freeTxn: 250},
+			},
+			txidSets: [][]txid{
+				{110, 240},
+				{249},
+			},
+			wantFree: []pgid{3, 5, 7, 8},
 		},
 	}
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -705,12 +705,11 @@ func TestTx_Rollback(t *testing.T) {
 	}
 }
 
-// TestTx_releaseRange ensures db.freePages handles page releases
+// TestTx_release ensures db.releasePages handles page releases
 // correctly when there are transaction that are no longer reachable
 // via any read/write transactions and are "between" ongoing read
-// transactions, which requires they must be freed by
-// freelist.releaseRange.
-func TestTx_releaseRange(t *testing.T) {
+// transactions, which requires they must be released by freelist.release.
+func TestTx_release(t *testing.T) {
 	// Set initial mmap size well beyond the limit we will hit in this
 	// test, since we are testing with long running read transactions
 	// and will deadlock if db.grow is triggered.
@@ -790,9 +789,9 @@ func TestTx_releaseRange(t *testing.T) {
 	rollback(hold4)
 	rollback(hold5)
 
-	// Execute a write transaction to trigger a releaseRange operation in the db
-	// that will free multiple ranges between the remaining open read transactions, now that the
-	// holds have been rolled back.
+	// Execute a write transaction to trigger a release operation in the db
+	// that will release pending pages both allocated and freed between the
+	// remaining open read transactions, now that the holds have been rolled back.
 	put("k4", "v4")
 
 	// Check that all long running reads still read correct values.


### PR DESCRIPTION
I'm reading over the source code, had a hardtime understanding the intention of `DB.freePages()`.

Eventually I figured it out, and I did some works to improve it:

- Renamed `freePages` to `releasePages`.

  `freePages` is not a good name since `DB.freePages()` is likely to be mixed up with `DB.freepages()`.

- Reimplemented `DB.freePages()` for clarity.

  To achieve this, I also rewrote `freelist.release/releaseRange` to make the intention more explicit. 

  Note that I slightly changed the condition determining whether free(d) pages are associated with read-only transactions, I consider that: if `page.AllocatedTxID` **<=** `ROTx.ID` **<** `page.FreedTxID`, then `page` is associated with `ROTx`, for beginning read-only transactions do **not** increment DB's next transaction ID.  I'm not sure if I'm on the right way, I'd like some advice.