### PR TITLE
Make sure failed tests report their exit code

### DIFF
--- a/quick_test.go
+++ b/quick_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	fmt.Fprintln(os.Stderr, "seed:", qseed)
 	fmt.Fprintf(os.Stderr, "quick settings: count=%v, items=%v, ksize=%v, vsize=%v\n", qcount, qmaxitems, qmaxksize, qmaxvsize)
 
-	m.Run()
+	os.Exit(m.Run())
 }
 
 func qconfig() *quick.Config {


### PR DESCRIPTION
Commit 72c1660c13cb8cf0d590d91fb03625a68e53900f introduced TestMain, but forgot to call os.Exit with the value returned from m.Run  This causes "go test" to exit with status 0, even if tests fail.  Adding os.Exit to TestMain makes sure the success/failure of tests is correctly reported through the exit code.