### PR TITLE
Use madvise syscall wrapper from golang.org/x/sys/unix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
 - 1.12
 
 before_install:
+- go get -v golang.org/x/sys/unix
 - go get -v honnef.co/go/tools/...
 - go get -v github.com/kisielk/errcheck
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module go.etcd.io/bbolt
 
 go 1.12
 
-require golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
+require golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
-golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Direct syscalls using syscall.Syscall(SYS_*, ...) should no longer be
used on darwin, see [1]. Instead, use the madvise syscall wrapper
provided by the golang.org/x/sys/unix package for all unix platforms.
This implement the same functionality.

[1] https://golang.org/doc/go1.12#darwin

As suggested by @ptabor in https://github.com/etcd-io/etcd/pull/12316#issuecomment-698193671