### PR TITLE
test: add buffer to a channel to avoid goroutine leak

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1122,7 +1122,7 @@ func TestDB_Batch(t *testing.T) {
 
 	// Iterate over multiple updates in separate goroutines.
 	n := 2
-	ch := make(chan error)
+	ch := make(chan error, n)
 	for i := 0; i < n; i++ {
 		go func(i int) {
 			ch <- db.Batch(func(tx *bolt.Tx) error {


### PR DESCRIPTION
**Description**

If `t.Fatal(err)` is called at line 1137, all child goroutines created at line 1127 will be blocked at `ch <- db.Batch(...)`.
After this commit, ch will have n buffers, so all send operations in child goroutines won't block. 
This patch is safe and doesn't change the semantics of the unit test, because it doesn't influence receive operations at line 1136.