### PR TITLE
Tiny Optimization : Replace method `size` with `sizeLessThan`  in `node.go` .

### DIFF
--- a/node.go
+++ b/node.go
@@ -413,7 +413,7 @@ func (n *node) rebalance() {
 
 	// Ignore if node is above threshold (25%) and has enough keys.
 	var threshold = n.bucket.tx.db.pageSize / 4
-	if n.size() > threshold && len(n.inodes) > n.minKeys() {
+	if !n.sizeLessThan(uintptr(threshold)) && len(n.inodes) > n.minKeys() {
 		return
 	}
 


### PR DESCRIPTION
Well, I'm reading source code of bbolt, and I found there is the last method `size` that can be replaced with `sizeLessThan` . So, why not do it now.