### PR TITLE
tx: remove outdated comment

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -188,7 +188,6 @@ func (tx *Tx) Commit() error {
 	}
 
 	// If strict mode is enabled then perform a consistency check.
-	// Only the first consistency error is reported in the panic.
 	if tx.db.StrictMode {
 		ch := tx.Check()
 		var errs []string


### PR DESCRIPTION
According to [this commit](https://github.com/etcd-io/bbolt/commit/37e96de68dcc7f3ee75e2a96410b2688553d9b82), it reports errs in the panic instead of the first one.