### PR TITLE
Add `Mlock` flag.

### DIFF
--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -51,7 +51,7 @@ func funlock(db *DB) error {
 // mmap memory maps a DB's data file.
 func mmap(db *DB, sz int) error {
 	// Map the data file to memory.
-	b, err := syscall.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED|db.MmapFlags)
+	b, err := unix.Mmap(int(db.file.Fd()), 0, sz, syscall.PROT_READ, syscall.MAP_SHARED|db.MmapFlags)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func munmap(db *DB) error {
 	}
 
 	// Unmap using the original byte slice.
-	err := syscall.Munmap(db.dataref)
+	err := unix.Munmap(db.dataref)
 	db.dataref = nil
 	db.data = nil
 	db.datasz = 0

--- a/mlock_unix.go
+++ b/mlock_unix.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package bbolt
+
+import "golang.org/x/sys/unix"
+
+// mlock locks memory of db file
+func mlock(db *DB, fileSize int) error {
+	sizeToLock := fileSize
+	if sizeToLock > db.datasz {
+		// Can't lock more than mmaped slice
+		sizeToLock = db.datasz
+	}
+	if err := unix.Mlock(db.dataref[:sizeToLock]); err != nil {
+		return err
+	}
+	return nil
+}
+
+//munlock unlocks memory of db file
+func munlock(db *DB, fileSize int) error {
+	if db.dataref == nil {
+		return nil
+	}
+
+	sizeToUnlock := fileSize
+	if sizeToUnlock > db.datasz {
+		// Can't unlock more than mmaped slice
+		sizeToUnlock = db.datasz
+	}
+
+	if err := unix.Munlock(db.dataref[:sizeToUnlock]); err != nil {
+		return err
+	}
+	return nil
+}

--- a/mlock_windows.go
+++ b/mlock_windows.go
@@ -1,0 +1,11 @@
+package bbolt
+
+// mlock locks memory of db file
+func mlock(_ *DB, _ int) error {
+	panic("mlock is supported only on UNIX systems")
+}
+
+//munlock unlocks memory of db file
+func munlock(_ *DB, _ int) error {
+	panic("munlock is supported only on UNIX systems")
+}

--- a/unix_test.go
+++ b/unix_test.go
@@ -1,0 +1,116 @@
+// +build !windows
+
+package bbolt_test
+
+import (
+	"fmt"
+	"testing"
+
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/sys/unix"
+)
+
+func TestMlock_DbOpen(t *testing.T) {
+	// 32KB
+	skipOnMemlockLimitBelow(t, 32*1024)
+
+	db := MustOpenWithOption(&bolt.Options{Mlock: true})
+	defer db.MustClose()
+}
+
+// Test change between "empty" (16KB) and "non-empty" db
+func TestMlock_DbCanGrow_Small(t *testing.T) {
+	// 32KB
+	skipOnMemlockLimitBelow(t, 32*1024)
+
+	db := MustOpenWithOption(&bolt.Options{Mlock: true})
+	defer db.MustClose()
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("bucket"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		key := []byte("key")
+		value := []byte("value")
+		if err := b.Put(key, value); err != nil {
+			t.Fatal(err)
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+// Test crossing of 16MB (AllocSize) of db size
+func TestMlock_DbCanGrow_Big(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	// 32MB
+	skipOnMemlockLimitBelow(t, 32*1024*1024)
+
+	chunksBefore := 64
+	chunksAfter := 64
+
+	db := MustOpenWithOption(&bolt.Options{Mlock: true})
+	defer db.MustClose()
+
+	for chunk := 0; chunk < chunksBefore; chunk++ {
+		insertChunk(t, db, chunk)
+	}
+	dbSize := fileSize(db.f)
+
+	for chunk := 0; chunk < chunksAfter; chunk++ {
+		insertChunk(t, db, chunksBefore+chunk)
+	}
+	newDbSize := fileSize(db.f)
+
+	if newDbSize <= dbSize {
+		t.Errorf("db didn't grow: %v <= %v", newDbSize, dbSize)
+	}
+}
+
+func insertChunk(t *testing.T, db *DB, chunkId int) {
+	chunkSize := 1024
+
+	if err := db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("bucket"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < chunkSize; i++ {
+			key := []byte(fmt.Sprintf("key-%d-%d", chunkId, i))
+			value := []byte("value")
+			if err := b.Put(key, value); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Main reason for this check is travis limiting mlockable memory to 64KB
+// https://github.com/travis-ci/travis-ci/issues/2462
+func skipOnMemlockLimitBelow(t *testing.T, memlockLimitRequest uint64) {
+	var info unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_MEMLOCK, &info); err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Cur < memlockLimitRequest {
+		t.Skip(fmt.Sprintf(
+			"skipping as RLIMIT_MEMLOCK is unsufficient: %v < %v",
+			info.Cur,
+			memlockLimitRequest,
+		))
+	}
+}


### PR DESCRIPTION
`Mlock` flag will cause mlock on db file which will prevent memory swapping of it. Motivation of this commit is https://github.com/etcd-io/etcd/pull/12750

My concerns (feedback very welcome):
- Can full `munlock` and then full `mlock` after file growth be replaced with single `mlock` of new file chunk?
- Should `mlock` and `munlock` functions from `bolt_unix.go` be copied into **bolt_unix_aix.go** and **bolt_unix_solaris.go** (as `mmap` and `munmap` is)?
- How to test such OS-specific flag? I'm not aware of any OS-specific test.