### PR TITLE
Skip few long running tests in `-short` mode

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1185,6 +1185,10 @@ func TestBucket_Put_ValueTooLarge(t *testing.T) {
 
 // Ensure a bucket can calculate stats.
 func TestBucket_Stats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	db := MustOpenDB()
 	defer db.MustClose()
 

--- a/db_test.go
+++ b/db_test.go
@@ -66,6 +66,10 @@ func TestOpen(t *testing.T) {
 // Regression validation for https://github.com/etcd-io/bbolt/pull/122.
 // Tests multiple goroutines simultaneously opening a database.
 func TestOpen_MultipleGoroutines(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	const (
 		instances  = 30
 		iterations = 30

--- a/manydbs_test.go
+++ b/manydbs_test.go
@@ -61,6 +61,10 @@ func createAndPutKeys(t *testing.T) {
 }
 
 func TestManyDBs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
 	for i := 0; i < 100; i++ {
 		t.Run(fmt.Sprintf("%d", i), createAndPutKeys)
 	}


### PR DESCRIPTION
Skip 3 tests in `-short` mode. Goal is to allow continuous testing during development.

Using below line
```
TEST_FREELIST_TYPE=hashmap go test -v -timeout 20m -short
```
yields below time gains:

on Macbook Pro (4cores/16GB)
219s -> 22s
on some strong VM (16cores/64GB)
31s -> 6s