### PR TITLE
Record the amount of free pages instead of hashmapFreeCount calculation

### DIFF
--- a/db.go
+++ b/db.go
@@ -40,6 +40,9 @@ const (
 // default page size for db is set to the OS page size.
 var defaultPageSize = os.Getpagesize()
 
+// When enabled, the database will perform assert function to check the slow-path code
+var assertVerify = os.Getenv("BBOLT_VERIFY") == "true"
+
 // The time elapsed between consecutive file locking attempts.
 const flockRetryTimeout = 50 * time.Millisecond
 
@@ -1227,6 +1230,12 @@ func (m *meta) sum64() uint64 {
 // _assert will panic with a given formatted message if the given condition is false.
 func _assert(condition bool, msg string, v ...interface{}) {
 	if !condition {
+		panic(fmt.Sprintf("assertion failed: "+msg, v...))
+	}
+}
+
+func _assertVerify(conditionFunc func() bool, msg string, v ...interface{}) {
+	if assertVerify && !conditionFunc() {
 		panic(fmt.Sprintf("assertion failed: "+msg, v...))
 	}
 }

--- a/freelist.go
+++ b/freelist.go
@@ -28,6 +28,7 @@ type freelist struct {
 	freemaps       map[uint64]pidSet           // key is the size of continuous pages(span), value is a set which contains the starting pgids of same size
 	forwardMap     map[pgid]uint64             // key is start pgid, value is its span size
 	backwardMap    map[pgid]uint64             // key is end pgid, value is its span size
+	freePagesCount uint64                      // count of free pages(hashmap version)
 	allocate       func(txid txid, n int) pgid // the freelist allocate func
 	free_count     func() int                  // the function which gives you free page number
 	mergeSpans     func(ids pgids)             // the mergeSpan func

--- a/freelist_hmap.go
+++ b/freelist_hmap.go
@@ -4,7 +4,11 @@ import "sort"
 
 // hashmapFreeCount returns count of free pages(hashmap version)
 func (f *freelist) hashmapFreeCount() int {
-	// use the forwardMap to get the total count
+	_assertVerify(func() bool { return int(f.freePagesCount) == f.hashmapFreeCountSlow() }, "freePagesCount is out of sync with free pages map")
+	return int(f.freePagesCount)
+}
+
+func (f *freelist) hashmapFreeCountSlow() int {
 	count := 0
 	for _, size := range f.forwardMap {
 		count += int(size)
@@ -130,6 +134,7 @@ func (f *freelist) addSpan(start pgid, size uint64) {
 	}
 
 	f.freemaps[size][start] = struct{}{}
+	f.freePagesCount += size
 }
 
 func (f *freelist) delSpan(start pgid, size uint64) {
@@ -139,6 +144,7 @@ func (f *freelist) delSpan(start pgid, size uint64) {
 	if len(f.freemaps[size]) == 0 {
 		delete(f.freemaps, size)
 	}
+	f.freePagesCount -= size
 }
 
 // initial from pgids using when use hashmap version
@@ -150,6 +156,8 @@ func (f *freelist) init(pgids []pgid) {
 
 	size := uint64(1)
 	start := pgids[0]
+	// reset the counter when freelist init
+	f.freePagesCount = 0
 
 	if !sort.SliceIsSorted([]pgid(pgids), func(i, j int) bool { return pgids[i] < pgids[j] }) {
 		panic("pgids not sorted")


### PR DESCRIPTION
reduce the cost of etcd compaction with record the amount of free pages


![image](https://user-images.githubusercontent.com/54933318/122872934-be212b80-d363-11eb-8d46-31ba531ef180.png)
