### PR TITLE
Use `golang.org/x/sys/windows` for `FileLockEx`/`UnlockFileEx`

### DIFF
--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -6,39 +6,9 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
-
-// LockFileEx code derived from golang build filemutex_windows.go @ v1.5.1
-var (
-	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
-	procLockFileEx   = modkernel32.NewProc("LockFileEx")
-	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
-)
-
-const (
-	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
-	flagLockExclusive       = 2
-	flagLockFailImmediately = 1
-
-	// see https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
-	errLockViolation syscall.Errno = 0x21
-)
-
-func lockFileEx(h syscall.Handle, flags, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
-	r, _, err := procLockFileEx.Call(uintptr(h), uintptr(flags), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)))
-	if r == 0 {
-		return err
-	}
-	return nil
-}
-
-func unlockFileEx(h syscall.Handle, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
-	r, _, err := procUnlockFileEx.Call(uintptr(h), uintptr(reserved), uintptr(locklow), uintptr(lockhigh), uintptr(unsafe.Pointer(ol)), 0)
-	if r == 0 {
-		return err
-	}
-	return nil
-}
 
 // fdatasync flushes written data to a file descriptor.
 func fdatasync(db *DB) error {
@@ -51,22 +21,22 @@ func flock(db *DB, exclusive bool, timeout time.Duration) error {
 	if timeout != 0 {
 		t = time.Now()
 	}
-	var flag uint32 = flagLockFailImmediately
+	var flags uint32 = windows.LOCKFILE_FAIL_IMMEDIATELY
 	if exclusive {
-		flag |= flagLockExclusive
+		flags |= windows.LOCKFILE_EXCLUSIVE_LOCK
 	}
 	for {
 		// Fix for https://github.com/etcd-io/bbolt/issues/121. Use byte-range
 		// -1..0 as the lock on the database file.
 		var m1 uint32 = (1 << 32) - 1 // -1 in a uint32
-		err := lockFileEx(syscall.Handle(db.file.Fd()), flag, 0, 1, 0, &syscall.Overlapped{
+		err := windows.LockFileEx(windows.Handle(db.file.Fd()), flags, 0, 1, 0, &windows.Overlapped{
 			Offset:     m1,
 			OffsetHigh: m1,
 		})
 
 		if err == nil {
 			return nil
-		} else if err != errLockViolation {
+		} else if err != windows.ERROR_LOCK_VIOLATION {
 			return err
 		}
 
@@ -83,11 +53,10 @@ func flock(db *DB, exclusive bool, timeout time.Duration) error {
 // funlock releases an advisory lock on a file descriptor.
 func funlock(db *DB) error {
 	var m1 uint32 = (1 << 32) - 1 // -1 in a uint32
-	err := unlockFileEx(syscall.Handle(db.file.Fd()), 0, 1, 0, &syscall.Overlapped{
+	return windows.UnlockFileEx(windows.Handle(db.file.Fd()), 0, 1, 0, &windows.Overlapped{
 		Offset:     m1,
 		OffsetHigh: m1,
 	})
-	return err
 }
 
 // mmap memory maps a DB's data file.


### PR DESCRIPTION
Use the `FileLockEx` and `UnlockFileEx` wrappers and the corresponding
`LOCKFILE_*` and the `ERROR_LOCK_VIOLATION` error constant from the
`golang.org/x/sys/windows` package rather than implementing these in the
package.