### PR TITLE
display progress during benchmark

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1620,8 +1620,8 @@ func (cmd *BenchCommand) checkProgress(results *BenchResults, finishChan chan in
 			return
 		case t := <-ticker:
 			completed, taken := results.CompletedOps, t.Sub(lastTime)
-			fmt.Fprintf(cmd.Stderr, "Completed %d requests, %3.1f/s \n",
-				completed, float64(completed-lastCompleted)*float64(int64(time.Second))/float64(int64(taken)),
+			fmt.Fprintf(cmd.Stderr, "Completed %d requests, %d/s \n",
+				completed, ((completed-lastCompleted)*int64(time.Second))/int64(taken),
 			)
 			lastCompleted, lastTime = completed, t
 		}

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1298,7 +1298,7 @@ func (cmd *BenchCommand) Run(args ...string) error {
 
 	// Remove path if "-work" is not set. Otherwise keep path.
 	if options.Work {
-		fmt.Fprintf(cmd.Stdout, "work: %s\n", options.Path)
+		fmt.Fprintf(cmd.Stderr, "work: %s\n", options.Path)
 	} else {
 		defer os.Remove(options.Path)
 	}
@@ -1313,13 +1313,13 @@ func (cmd *BenchCommand) Run(args ...string) error {
 
 	// Write to the database.
 	writeResults := BenchResults{int64(0), 0}
-	fmt.Fprintf(cmd.Stdout, "starting write benchmark.\n")
+	fmt.Fprintf(cmd.Stderr, "starting write benchmark.\n")
 	if err := cmd.runWrites(db, options, &writeResults); err != nil {
 		return fmt.Errorf("write: %v", err)
 	}
 
 	readResults := BenchResults{int64(0), 0}
-	fmt.Fprintf(cmd.Stdout, "starting read benchmark.\n")
+	fmt.Fprintf(cmd.Stderr, "starting read benchmark.\n")
 	// Read from the database.
 	if err := cmd.runReads(db, options, &readResults); err != nil {
 		return fmt.Errorf("bench: read: %s", err)
@@ -1620,7 +1620,7 @@ func (cmd *BenchCommand) checkProgress(results *BenchResults, finishChan chan in
 			return
 		case t := <-ticker:
 			completed, taken := results.CompletedOps, t.Sub(lastTime)
-			fmt.Fprintf(cmd.Stdout, "Completed %d requests, %3.1f/s \n",
+			fmt.Fprintf(cmd.Stderr, "Completed %d requests, %3.1f/s \n",
 				completed, float64(completed-lastCompleted)*float64(int64(time.Second))/float64(int64(taken)),
 			)
 			lastCompleted, lastTime = completed, t


### PR DESCRIPTION
$ ./bbolt bench -batch-size 10 -count 10000 -key-size 100 -path bolt.db -value-size 200 -write-mode rnd
starting write benchmark.
Completed 350 requests, 349.9/s 
Completed 760 requests, 409.5/s 
Completed 1150 requests, 389.1/s 
Completed 1560 requests, 411.3/s 
Completed 1970 requests, 410.1/s 
Completed 2420 requests, 449.3/s 
Completed 2870 requests, 450.8/s 
Completed 3290 requests, 419.9/s 
Completed 3730 requests, 440.1/s 
Completed 4150 requests, 418.5/s 
Completed 4590 requests, 441.0/s 
Completed 5030 requests, 440.6/s