### PR TITLE
compact: add cli flag to control NoSync option

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1572,6 +1572,7 @@ type compactCommand struct {
 	SrcPath   string
 	DstPath   string
 	TxMaxSize int64
+	DstNoSync bool
 }
 
 // newCompactCommand returns a CompactCommand.
@@ -1588,6 +1589,7 @@ func (cmd *compactCommand) Run(args ...string) (err error) {
 	fs.SetOutput(io.Discard)
 	fs.StringVar(&cmd.DstPath, "o", "", "")
 	fs.Int64Var(&cmd.TxMaxSize, "tx-max-size", 65536, "")
+	fs.BoolVar(&cmd.DstNoSync, "no-sync", false, "")
 	if err := fs.Parse(args); err == flag.ErrHelp {
 		fmt.Fprintln(cmd.Stderr, cmd.Usage())
 		return ErrUsage
@@ -1620,7 +1622,7 @@ func (cmd *compactCommand) Run(args ...string) (err error) {
 	defer src.Close()
 
 	// Open destination database.
-	dst, err := bolt.Open(cmd.DstPath, fi.Mode(), nil)
+	dst, err := bolt.Open(cmd.DstPath, fi.Mode(), &bolt.Options{NoSync: cmd.DstNoSync})
 	if err != nil {
 		return err
 	}
@@ -1658,6 +1660,10 @@ Additional options include:
 	-tx-max-size NUM
 		Specifies the maximum size of individual transactions.
 		Defaults to 64KB.
+
+	-no-sync BOOL
+		Skip fsync() calls after each commit (fast but unsafe)
+		Defaults to false
 `, "\n")
 }
 


### PR DESCRIPTION
The `compact` CLI command is very slow by default, this PR adds two new CLI flags which can be used to control the `db.NoSync` and `db.NoFreelistSync` values when creating the destination database.

 Usage:
 
 ```bash
 go run cmd/bbolt/main.go compact -no-sync -no-freelist-sync -o out.db in.db
 ```
 
 Enabling these flags had a huge impact on performance, resulting in significantly expedited `compact` operations.
 
 I would potentially advocate defaulting them to `true`, but that's a discussion for another day..