### PR TITLE
make NoSync more effective

### DIFF
--- a/db.go
+++ b/db.go
@@ -505,8 +505,10 @@ func (db *DB) init() error {
 	if _, err := db.ops.writeAt(buf, 0); err != nil {
 		return err
 	}
-	if err := fdatasync(db); err != nil {
-		return err
+	if !db.NoSync || IgnoreNoSync {
+		if err := fdatasync(db); err != nil {
+			return err
+		}
 	}
 	db.filesz = len(buf)
 
@@ -1017,8 +1019,10 @@ func (db *DB) grow(sz int) error {
 				return fmt.Errorf("file resize error: %s", err)
 			}
 		}
-		if err := db.file.Sync(); err != nil {
-			return fmt.Errorf("file sync error: %s", err)
+		if !db.NoSync || IgnoreNoSync {
+			if err := db.file.Sync(); err != nil {
+				return fmt.Errorf("file sync error: %s", err)
+			}
 		}
 		if db.Mlock {
 			// unlock old file and lock new one


### PR DESCRIPTION
The database init and grow operations still used fsync even when
NoSync was set, on the grounds that these operations are comparatively
rare and it makes sense to want them to be more reliable even at
some marginal cost in speed.

But if you're doing tests on something which happens to *use*
boltdb lightly, so it creates databases but barely touches them, this
can result in hundreds and hundreds of fsyncs, possibly in parallel,
and that becomes expensive.

Worth noting: Yes, it's intentional that the grow() case is using
db.file.Sync() rather than fdatasync(). On some platforms, fdatasync()
may not cause filesystem metadata updates to get flushed, just raw
file data block updates. We optimistically hope that (File).Sync() will
do the right thing.