### PR TITLE
compact: open src file readonly

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1979,7 +1979,7 @@ func (cmd *CompactCommand) Run(args ...string) (err error) {
 	initialSize := fi.Size()
 
 	// Open source database.
-	src, err := bolt.Open(cmd.SrcPath, 0444, nil)
+	src, err := bolt.Open(cmd.SrcPath, 0444, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
the `compact` CLI command [opens the **source** file](https://github.com/etcd-io/bbolt/blob/master/cmd/bbolt/main.go#L1981) as `0444` but doesn't currently set `ReadOnly: true`.

it therefore requests a `read-write` file lock on the **source** database when it only really needs `read-only`.

this is due to the [flock code](https://github.com/etcd-io/bbolt/blob/master/db.go#L223-L233) only considering the `db.readOnly` bool and not the `os.FileMode`.

the problem is that if one or more processes have `read-only` locks then this operation will stall waiting to acquire a write lock that it doesn't need 🤷‍♂️ 

with this PR the `ReadOnly: true` option is set explicitly, meaning that it will play nice with other processes which are also read-only.
