### PR TITLE
db: set db.readOnly for file permissions with no write bits set

### DIFF
--- a/db.go
+++ b/db.go
@@ -202,7 +202,7 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 	db.AllocSize = DefaultAllocSize
 
 	flag := os.O_RDWR
-	if options.ReadOnly {
+	if options.ReadOnly || (mode&0222 == 0) {
 		flag = os.O_RDONLY
 		db.readOnly = true
 	}


### PR DESCRIPTION
when a database is opened `0444` this implies `options.ReadOnly`.

this PR checks the `os.FileMode` permissions to see if a write bit has been set.

in the event the file was opened with file permissions which prohibit writing to it then a `read-only` flock will be acquired instead of a `read-write` lock.

related to https://github.com/etcd-io/bbolt/pull/292