### PR TITLE
Upgrade golang to 1.17 and replace iouitl with io and os

### DIFF
--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -1,3 +1,4 @@
+//go:build arm64
 // +build arm64
 
 package bbolt

--- a/bolt_mips64x.go
+++ b/bolt_mips64x.go
@@ -1,3 +1,4 @@
+//go:build mips64 || mips64le
 // +build mips64 mips64le
 
 package bbolt

--- a/bolt_mipsx.go
+++ b/bolt_mipsx.go
@@ -1,3 +1,4 @@
+//go:build mips || mipsle
 // +build mips mipsle
 
 package bbolt

--- a/bolt_ppc.go
+++ b/bolt_ppc.go
@@ -1,3 +1,4 @@
+//go:build ppc
 // +build ppc
 
 package bbolt

--- a/bolt_ppc64.go
+++ b/bolt_ppc64.go
@@ -1,3 +1,4 @@
+//go:build ppc64
 // +build ppc64
 
 package bbolt

--- a/bolt_ppc64le.go
+++ b/bolt_ppc64le.go
@@ -1,3 +1,4 @@
+//go:build ppc64le
 // +build ppc64le
 
 package bbolt

--- a/bolt_riscv64.go
+++ b/bolt_riscv64.go
@@ -1,3 +1,4 @@
+//go:build riscv64
 // +build riscv64
 
 package bbolt

--- a/bolt_s390x.go
+++ b/bolt_s390x.go
@@ -1,3 +1,4 @@
+//go:build s390x
 // +build s390x
 
 package bbolt

--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !plan9 && !solaris && !aix
 // +build !windows,!plan9,!solaris,!aix
 
 package bbolt

--- a/bolt_unix_aix.go
+++ b/bolt_unix_aix.go
@@ -1,3 +1,4 @@
+//go:build aix
 // +build aix
 
 package bbolt

--- a/boltsync_unix.go
+++ b/boltsync_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !plan9 && !linux && !openbsd
 // +build !windows,!plan9,!linux,!openbsd
 
 package bbolt

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -1364,7 +1363,7 @@ func (cmd *BenchCommand) ParseFlags(args []string) (*BenchOptions, error) {
 
 	// Generate temp path if one is not passed in.
 	if options.Path == "" {
-		f, err := ioutil.TempFile("", "bolt-bench-")
+		f, err := os.CreateTemp("", "bolt-bench-")
 		if err != nil {
 			return nil, fmt.Errorf("temp file: %s", err)
 		}
@@ -1951,7 +1950,7 @@ func newCompactCommand(m *Main) *CompactCommand {
 func (cmd *CompactCommand) Run(args ...string) (err error) {
 	// Parse flags.
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.SetOutput(ioutil.Discard)
+	fs.SetOutput(io.Discard)
 	fs.StringVar(&cmd.DstPath, "o", "", "")
 	fs.Int64Var(&cmd.TxMaxSize, "tx-max-size", 65536, "")
 	if err := fs.Parse(args); err == flag.ErrHelp {

--- a/cmd/bbolt/main_test
+++ b/cmd/bbolt/main_test
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strconv"
@@ -265,7 +264,7 @@ func NewMain() *Main {
 // MustOpen creates a Bolt database in a temporary location.
 func MustOpen(mode os.FileMode, options *bolt.Options) *DB {
 	// Create temporary path.
-	f, _ := ioutil.TempFile("", "bolt-")
+	f, _ := os.CreateTemp("", "bolt-")
 	f.Close()
 	os.Remove(f.Name())
 

--- a/db_test.go
+++ b/db_test.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"hash/fnv"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -158,7 +157,7 @@ func TestOpen_ErrVersionMismatch(t *testing.T) {
 	}
 
 	// Read data file.
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +167,7 @@ func TestOpen_ErrVersionMismatch(t *testing.T) {
 	meta0.version++
 	meta1 := (*meta)(unsafe.Pointer(&buf[pageSize+pageHeaderSize]))
 	meta1.version++
-	if err := ioutil.WriteFile(path, buf, 0666); err != nil {
+	if err := os.WriteFile(path, buf, 0666); err != nil {
 		t.Fatal(err)
 	}
 
@@ -195,7 +194,7 @@ func TestOpen_ErrChecksum(t *testing.T) {
 	}
 
 	// Read data file.
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +204,7 @@ func TestOpen_ErrChecksum(t *testing.T) {
 	meta0.pgid++
 	meta1 := (*meta)(unsafe.Pointer(&buf[pageSize+pageHeaderSize]))
 	meta1.pgid++
-	if err := ioutil.WriteFile(path, buf, 0666); err != nil {
+	if err := os.WriteFile(path, buf, 0666); err != nil {
 		t.Fatal(err)
 	}
 
@@ -643,7 +642,7 @@ func TestDB_Concurrent_WriteTo(t *testing.T) {
 	wg.Add(wtxs * rtxs)
 	f := func(tx *bolt.Tx) {
 		defer wg.Done()
-		f, err := ioutil.TempFile("", "bolt-")
+		f, err := os.CreateTemp("", "bolt-")
 		if err != nil {
 			panic(err)
 		}
@@ -1747,7 +1746,7 @@ func (db *DB) CopyTempFile() {
 
 // tempfile returns a temporary file path.
 func tempfile() string {
-	f, err := ioutil.TempFile("", "bolt-")
+	f, err := os.CreateTemp("", "bolt-")
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.etcd.io/bbolt
 
-go 1.12
+go 1.17
 
 require golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d

--- a/manydbs_test.go
+++ b/manydbs_test.go
@@ -2,7 +2,6 @@ package bbolt
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -12,7 +11,7 @@ import (
 func createDb(t *testing.T) (*DB, func()) {
 	// First, create a temporary directory to be used for the duration of
 	// this test.
-	tempDirName, err := ioutil.TempDir("", "bboltmemtest")
+	tempDirName, err := os.MkdirTemp("", "bboltmemtest")
 	if err != nil {
 		t.Fatalf("error creating temp dir: %v", err)
 	}

--- a/mlock_unix.go
+++ b/mlock_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package bbolt

--- a/unix_test.go
+++ b/unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package bbolt_test


### PR DESCRIPTION
bolt is still using golang 1.12, which is really too old. etcd has already upgraded golang to 1.17, so it'd better to upgrade golang to 1.17 for bolt as well. 

The ioutil package has already been deprecated in **golang 1.16**, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we also need to replace all the ioutil with os and io. 

In golang 1.17, the go command understands //go:build lines and prefer them over // +build lines. Please see [go1.17#go-command](https://golang.org/doc/go1.17#go-command). So added the "//go:build" lines as well in this PR.
