### PR TITLE
fix lmdb link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ and setting values. That's it.
 [gh_ben]: https://github.com/benbjohnson
 [bolt]: https://github.com/boltdb/bolt
 [hyc_symas]: https://twitter.com/hyc_symas
-[lmdb]: http://symas.com/mdb/
+[lmdb]: https://www.symas.com/symas-embedded-database-lmdb
 
 ## Project Status
 


### PR DESCRIPTION
The lmdb link which in README is invaild, change to https://www.symas.com/symas-embedded-database-lmdb