### PR TITLE
cmd/bbolt: re-enable "bbolt" testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,11 @@ lint:
 
 test:
 	TEST_FREELIST_TYPE=hashmap go test -timeout 20m -v -coverprofile cover.out -covermode atomic
-	# Note: gets "program not an importable package" in out of path builds
 	TEST_FREELIST_TYPE=hashmap go test -v ./cmd/bbolt
 
 	@echo "array freelist test"
 
 	@TEST_FREELIST_TYPE=array go test -timeout 20m -v -coverprofile cover.out -covermode atomic
-	# Note: gets "program not an importable package" in out of path builds
 	@TEST_FREELIST_TYPE=array go test -v ./cmd/bbolt
 
 .PHONY: race fmt test lint

--- a/cmd/bbolt/main_test.go
+++ b/cmd/bbolt/main_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	bolt "go.etcd.io/bbolt"
+	main "go.etcd.io/bbolt/cmd/bbolt"
 )
 
 // Ensure the "info" command can print information about a database.


### PR DESCRIPTION
as per https://github.com/etcd-io/bbolt/issues/314 this PR reverts https://github.com/etcd-io/bbolt/commit/b951856120dd57364e7187080f91d3d87f3c59a8

the `import main "go.etcd.io/bbolt/cmd/bbolt"` statement was crucial to getting this running, absence of this might have been the reason why it was originally disabled. It's really not very intuitive 🤷‍♂️ 

note the file rename not obvious in the diff `cmd/bbolt/main_test → cmd/bbolt/main_test.go`