### PR TITLE
chore: update golang.org/x/sys module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module go.etcd.io/bbolt
 
 go 1.17
 
-require golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d
+require golang.org/x/sys v0.0.0-20220818161305-2296e01440c6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 h1:Sx/u41w+OwrInGdEckYmEuU5gHoGSL4QbDz3S9s6j4U=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Update module golang.org/x/sys to latest, in order to enable building with go >=1.18.

Using go 1.18.5 on MacOS 12.4 arm64, building bbolt results in errors of this flavor:

```
% go build
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/syscall_darwin.1_13.go:29:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.1_13.go:27:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.1_13.go:40:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.5/global/pkg/mod/golang.org/x/sys@v0.0.0-20200923182605-d9f96fdee20d/unix/zsyscall_darwin_arm64.go:121:3: too many errors
```

The issue can be resolved by using go <1.18, or by updating the module golang.org/x/sys. https://github.com/golang/go/issues/51091