### PR TITLE
Add example for Bucket.Delete() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,16 @@ set to a key which is different than the key not existing.
 
 Use the `Bucket.Delete()` function to delete a key from the bucket.
 
+```go
+db.Update(func (tx *bolt.Tx) error {
+    b := tx.Bucket([]byte("MyBucket"))
+    b.Delete([]byte("answer"))
+    return nil
+})
+```
+
+This will delete the key `answers` from the bucket `MyBucket`.
+
 Please note that values returned from `Get()` are only valid while the
 transaction is open. If you need to use a value outside of the transaction
 then you must use `copy()` to copy it to another byte slice.

--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ Use the `Bucket.Delete()` function to delete a key from the bucket.
 ```go
 db.Update(func (tx *bolt.Tx) error {
     b := tx.Bucket([]byte("MyBucket"))
-    b.Delete([]byte("answer"))
-    return nil
+    err := b.Delete([]byte("answer"))
+    return err
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ exists then it will return its byte slice value. If it doesn't exist then it
 will return `nil`. It's important to note that you can have a zero-length value
 set to a key which is different than the key not existing.
 
-Use the `Bucket.Delete()` function to delete a key from the bucket.
+Use the `Bucket.Delete()` function to delete a key from the bucket:
 
 ```go
 db.Update(func (tx *bolt.Tx) error {


### PR DESCRIPTION
The example is similar to the examples for `Bucket.Put()` and `Bucket.Get()` functions, so it does not breaks the layout.
Signed-off-by: Sarthak2143 <sarthaktomar2143@gmail.com>