### PR TITLE
fix(cursor): `Last` method needs skip empty pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Note that we start to track changes starting from v1.3.7.
 
 ### BoltDB
 - [Add support for loong64 arch](https://github.com/etcd-io/bbolt/pull/303).
+- Fix [the "Last" method might return no data due to not skipping the empty pages](https://github.com/etcd-io/bbolt/pull/341)
 
 ### CMD
 - [Open db file readonly in compact CLI command](https://github.com/etcd-io/bbolt/pull/292).


### PR DESCRIPTION
In the same transaction, `Detete` may cause the last page to be empty. In this case, calling the Last method will return nill instead of the value of the previous page, which is incorrect.


1. suppose there is a bucket of 1000 elements
2. the structure diagram at this time
```
                          +---------------------+                                                                  
                          |     root bucket     |                                                                  
                +---------+---------------------+---------+                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
         +--------------------+                 +---------------------------+                                      
         |                    |                 |                           |                                      
 leaf1   |1，2，3，4.......300 |                 |301,302,303.......1000     |  leaf2                               
         |                    |                 |                           |                                      
         +--------------------+                 +---------------------------+           
```
3. now calling the `Last` method should return 1000
4. ok, now we call the `Delete` method to delete the last 800 elements
```
                          +---------------------+                                                                  
                          |     root bucket     |                                                                  
                +---------+---------------------+---------+                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
                |                                         |                                                        
         +----------------+                             +--+                                                       
         |                |                             |  |                                                       
 leaf1   |1，2，3......200 |                             |  |  leaf2 is empty                                       
         |                |                             |  |                                                       
         +----------------+                             +--+                                                       
                                                                                                                     
                                                                                                                   
   
```
5. bad thing happened, calling the `Last` method again returns nil, but I think it should return 200