### PR TITLE
bump golang.org/x/sys to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module go.etcd.io/bbolt
 
 go 1.17
 
-require golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d
+require golang.org/x/sys v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d h1:L/IKR6COd7ubZrs2oTnTi73IhgqJ71c9s80WsQnh0Es=
-golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
The current version `v0.0.0-20200923182605-d9f96fdee20d` is based on a specified commit SHA and is really too old, so bump to a tag based version `v0.2.0`

Signed-off-by: Benjamin Wang <wachao@vmware.com>