### PR TITLE
change freelist.cache from map[pgid]bool to map[pgid]struct{}

### DIFF
--- a/freelist.go
+++ b/freelist.go
@@ -24,7 +24,7 @@ type freelist struct {
 	ids            []pgid                      // all free and available free page ids.
 	allocs         map[pgid]txid               // mapping of txid that allocated a pgid.
 	pending        map[txid]*txPending         // mapping of soon-to-be free page ids by tx.
-	cache          map[pgid]bool               // fast lookup of all free and pending page ids.
+	cache          map[pgid]struct{}           // fast lookup of all free and pending page ids.
 	freemaps       map[uint64]pidSet           // key is the size of continuous pages(span), value is a set which contains the starting pgids of same size
 	forwardMap     map[pgid]uint64             // key is start pgid, value is its span size
 	backwardMap    map[pgid]uint64             // key is end pgid, value is its span size
@@ -41,7 +41,7 @@ func newFreelist(freelistType FreelistType) *freelist {
 		freelistType: freelistType,
 		allocs:       make(map[pgid]txid),
 		pending:      make(map[txid]*txPending),
-		cache:        make(map[pgid]bool),
+		cache:        make(map[pgid]struct{}),
 		freemaps:     make(map[uint64]pidSet),
 		forwardMap:   make(map[pgid]uint64),
 		backwardMap:  make(map[pgid]uint64),
@@ -171,13 +171,13 @@ func (f *freelist) free(txid txid, p *page) {
 
 	for id := p.id; id <= p.id+pgid(p.overflow); id++ {
 		// Verify that page is not already free.
-		if f.cache[id] {
+		if _, ok := f.cache[id]; ok {
 			panic(fmt.Sprintf("page %d already freed", id))
 		}
 		// Add to the freelist and cache.
 		txp.ids = append(txp.ids, id)
 		txp.alloctx = append(txp.alloctx, allocTxid)
-		f.cache[id] = true
+		f.cache[id] = struct{}{}
 	}
 }
 
@@ -257,7 +257,8 @@ func (f *freelist) rollback(txid txid) {
 
 // freed returns whether a given page is in the free list.
 func (f *freelist) freed(pgid pgid) bool {
-	return f.cache[pgid]
+	_, ok := f.cache[pgid]
+	return ok
 }
 
 // read initializes the freelist from a freelist page.
@@ -386,13 +387,13 @@ func (f *freelist) noSyncReload(pgids []pgid) {
 // reindex rebuilds the free cache based on available and pending free lists.
 func (f *freelist) reindex() {
 	ids := f.getFreePageIDs()
-	f.cache = make(map[pgid]bool, len(ids))
+	f.cache = make(map[pgid]struct{}, len(ids))
 	for _, id := range ids {
-		f.cache[id] = true
+		f.cache[id] = struct{}{}
 	}
 	for _, txp := range f.pending {
 		for _, pendingID := range txp.ids {
-			f.cache[pendingID] = true
+			f.cache[pendingID] = struct{}{}
 		}
 	}
 }


### PR DESCRIPTION
We just need to cache a list of freepage ID, and don't dare what's the value (`true` or `false`) at all, so changed the map's value from `bool` to `struct{}`.

Signed-off-by: Benjamin Wang <wachao@vmware.com>

@ptabor 