### PR TITLE
Validate page being fetched at possition 'p' self identifies as page 'p'

### DIFF
--- a/node.go
+++ b/node.go
@@ -188,7 +188,11 @@ func (n *node) read(p *page) {
 }
 
 // write writes the items onto one or more pages.
+// The page should have p.id (might be 0 for meta or bucket-inline page) and p.overflow set
+// and the rest should be zeroed.
 func (n *node) write(p *page) {
+	_assert(p.count == 0 && p.flags == 0, "node cannot be written into a not empty page")
+
 	// Initialize page.
 	if n.isLeaf {
 		p.flags = leafPageFlag

--- a/node.go
+++ b/node.go
@@ -191,9 +191,9 @@ func (n *node) read(p *page) {
 func (n *node) write(p *page) {
 	// Initialize page.
 	if n.isLeaf {
-		p.flags |= leafPageFlag
+		p.flags = leafPageFlag
 	} else {
-		p.flags |= branchPageFlag
+		p.flags = branchPageFlag
 	}
 
 	if len(n.inodes) >= 0xFFFF {

--- a/page.go
+++ b/page.go
@@ -2,6 +2,7 @@ package bbolt
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"sort"
 	"unsafe"
@@ -51,6 +52,12 @@ func (p *page) typ() string {
 // meta returns a pointer to the metadata section of the page.
 func (p *page) meta() *meta {
 	return (*meta)(unsafeAdd(unsafe.Pointer(p), unsafe.Sizeof(*p)))
+}
+
+func (p *page) fastCheck(id pgid) {
+	if p.id != id {
+		log.Panicf("Page expected to be: %v, but self identifies as %v", id, p.id)
+	}
 }
 
 // leafPageElement retrieves the leaf node by index

--- a/page.go
+++ b/page.go
@@ -2,7 +2,6 @@ package bbolt
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"sort"
 	"unsafe"
@@ -55,9 +54,13 @@ func (p *page) meta() *meta {
 }
 
 func (p *page) fastCheck(id pgid) {
-	if p.id != id {
-		log.Panicf("Page expected to be: %v, but self identifies as %v", id, p.id)
-	}
+	_assert(p.id == id, "Page expected to be: %v, but self identifies as %v", id, p.id)
+	// Only one flag of page-type can be set.
+	_assert(p.flags == branchPageFlag ||
+		p.flags == leafPageFlag ||
+		p.flags == metaPageFlag ||
+		p.flags == freelistPageFlag,
+		"page %v: has unexpected type/flags: %x", p.id, p.flags)
 }
 
 // leafPageElement retrieves the leaf node by index

--- a/tx.go
+++ b/tx.go
@@ -609,12 +609,15 @@ func (tx *Tx) page(id pgid) *page {
 	// Check the dirty pages first.
 	if tx.pages != nil {
 		if p, ok := tx.pages[id]; ok {
+			p.fastCheck(id)
 			return p
 		}
 	}
 
 	// Otherwise return directly from the mmap.
-	return tx.db.page(id)
+	p := tx.db.page(id)
+	p.fastCheck(id)
+	return p
 }
 
 // forEachPage iterates over every page within a given page and executes a function.


### PR DESCRIPTION
It's the easiest verification whether the page is actually written, or its 'random' garbage in the block.

For example for corruption from 'https://github.com/etcd-io/bbolt/issues/335' it will fail quickly with:
```
$ go build ./cmd/bbolt/ && ./bbolt check ~/Downloads/db
2022/12/17 15:45:48 Page expected to be: 821, but self identifies as 8314893338927566090
panic: Page expected to be: 821, but self identifies as 8314893338927566090

goroutine 1 [running]:
log.Panicf({0x102a8718e?, 0x14000118960?}, {0x14000118508?, 0x140000660c0?, 0x18b?})
        /usr/local/go/src/log/log.go:395 +0x68
go.etcd.io/bbolt.(*page).fastCheck(...)
        /Users/ptab/gits/bbolt/page.go:59
go.etcd.io/bbolt.(*Tx).page(0x12aa76000?, 0x10?)
        /Users/ptab/gits/bbolt/tx.go:619 +0x168
go.etcd.io/bbolt.(*Tx).forEachPage(0x12a5f3000?, 0x12aa55000?, 0x2, 0x14000118678)
        /Users/ptab/gits/bbolt/tx.go:625 +0x28
go.etcd.io/bbolt.(*Tx).forEachPage(0x12b60d000?, 0x0?, 0x1, 0x14000118678)
        /Users/ptab/gits/bbolt/tx.go:634 +0x8c
go.etcd.io/bbolt.(*Tx).forEachPage(0x140001086a8?, 0x102a711a4?, 0x0, 0x14000118678)
        /Users/ptab/gits/bbolt/tx.go:634 +0x8c
go.etcd.io/bbolt.(*Tx).checkBucket(0x14000110000, 0x14000022200, 0x14000118960, 0x14000118930, 0x140000660c0)
        /Users/ptab/gits/bbolt/tx.go:464 +0x98
go.etcd.io/bbolt.(*Tx).checkBucket.func2({0x12aa551b9?, 0x102a710c8?, 0x12aa55000?}, {0x102a67e84?, 0x14000108768?, 0x102a67e64?})
        /Users/ptab/gits/bbolt/tx.go:489 +0x70
go.etcd.io/bbolt.(*Bucket).ForEach(0x14000110018, 0x14000118798)
        /Users/ptab/gits/bbolt/bucket.go:390 +0xa8
go.etcd.io/bbolt.(*Tx).checkBucket(0x14000110000, 0x14000110018, 0x14000108960, 0x14000108930, 0x140000660c0)
        /Users/ptab/gits/bbolt/tx.go:487 +0xe0
go.etcd.io/bbolt.(*DB).freepages(0x102a7e12f?)
        /Users/ptab/gits/bbolt/db.go:1059 +0x154
go.etcd.io/bbolt.(*DB).loadFreelist.func1()
        /Users/ptab/gits/bbolt/db.go:320 +0xb8
sync.(*Once).doSlow(0x1400010c1c8?, 0x102ac05c0?)
        /usr/local/go/src/sync/once.go:74 +0x104
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:65
go.etcd.io/bbolt.(*DB).loadFreelist(0x1400010c000?)
        /Users/ptab/gits/bbolt/db.go:316 +0x48
go.etcd.io/bbolt.Open({0x16d45ba96, 0x18}, 0x1b6?, 0x0)
        /Users/ptab/gits/bbolt/db.go:293 +0x450
main.(*CheckCommand).Run(0x14000119e48, {0x140000101d0, 0x1, 0x1})
        /Users/ptab/gits/bbolt/cmd/bbolt/main.go:204 +0x16c
main.(*Main).Run(0x14000098f38, {0x140000101c0, 0x2, 0x2})
        /Users/ptab/gits/bbolt/cmd/bbolt/main.go:114 +0x794
main.main()
        /Users/ptab/gits/bbolt/cmd/bbolt/main.go:72 +0xb0
```



Signed-off-by: Piotr Tabor <ptab@google.com>