### PR TITLE
Extract from bbolt/CLI library for low-level inspection and modifications

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"go.etcd.io/bbolt/internal/guts_cli"
 	"io"
 	"math/rand"
 	"os"
@@ -19,6 +18,8 @@ import (
 	"unicode"
 	"unicode/utf8"
 	"unsafe"
+
+	"go.etcd.io/bbolt/internal/guts_cli"
 
 	bolt "go.etcd.io/bbolt"
 )

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"go.etcd.io/bbolt/internal/guts_cli"
 	"io"
 	"math/rand"
 	"os"
@@ -39,9 +40,6 @@ var (
 	// ErrInvalidValue is returned when a benchmark reads an unexpected value.
 	ErrInvalidValue = errors.New("invalid value")
 
-	// ErrCorrupt is returned when a checking a data file finds errors.
-	ErrCorrupt = errors.New("invalid value")
-
 	// ErrNonDivisibleBatchSize is returned when the batch size can't be evenly
 	// divided by the iteration count.
 	ErrNonDivisibleBatchSize = errors.New("number of iterations must be divisible by the batch size")
@@ -61,12 +59,6 @@ var (
 	// ErrKeyNotFound is returned when a key is not found.
 	ErrKeyNotFound = errors.New("key not found")
 )
-
-// PageHeaderSize represents the size of the bolt.page header.
-const PageHeaderSize = 16
-
-// Represents a marker value to indicate that a file (meta page) is a Bolt DB.
-const magic uint32 = 0xED0CDAED
 
 func main() {
 	m := NewMain()
@@ -219,7 +211,7 @@ func (cmd *CheckCommand) Run(args ...string) error {
 		// Print summary of errors.
 		if count > 0 {
 			fmt.Fprintf(cmd.Stdout, "%d errors found\n", count)
-			return ErrCorrupt
+			return guts_cli.ErrCorrupt
 		}
 
 		// Notify user that database is valid.
@@ -346,7 +338,7 @@ func (cmd *DumpCommand) Run(args ...string) error {
 	}
 
 	// Open database to retrieve page size.
-	pageSize, _, err := ReadPageAndHWMSize(path)
+	pageSize, _, err := guts_cli.ReadPageAndHWMSize(path)
 	if err != nil {
 		return err
 	}
@@ -499,7 +491,7 @@ func (cmd *PageItemCommand) Run(args ...string) error {
 	defer func() { _ = f.Close() }()
 
 	// Retrieve page info and page size.
-	_, buf, err := ReadPage(path, pageID)
+	_, buf, err := guts_cli.ReadPage(path, pageID)
 	if err != nil {
 		return err
 	}
@@ -520,15 +512,15 @@ func (cmd *PageItemCommand) Run(args ...string) error {
 }
 
 // leafPageElement retrieves a leaf page element.
-func (cmd *PageItemCommand) leafPageElement(pageBytes []byte, index uint16) (*leafPageElement, error) {
-	p := (*page)(unsafe.Pointer(&pageBytes[0]))
-	if index >= p.count {
-		return nil, fmt.Errorf("leafPageElement: expected item index less than %d, but got %d.", p.count, index)
+func (cmd *PageItemCommand) leafPageElement(pageBytes []byte, index uint16) (*guts_cli.LeafPageElement, error) {
+	p := (*guts_cli.Page)(unsafe.Pointer(&pageBytes[0]))
+	if index >= p.Count() {
+		return nil, fmt.Errorf("leafPageElement: expected item index less than %d, but got %d.", p.Count(), index)
 	}
 	if p.Type() != "leaf" {
 		return nil, fmt.Errorf("leafPageElement: expected page type of 'leaf', but got '%s'", p.Type())
 	}
-	return p.leafPageElement(index), nil
+	return p.LeafPageElement(index), nil
 }
 
 const FORMAT_MODES = "auto|ascii-encoded|hex|bytes|redacted"
@@ -584,7 +576,7 @@ func (cmd *PageItemCommand) PrintLeafItemKey(w io.Writer, pageBytes []byte, inde
 	if err != nil {
 		return err
 	}
-	return writelnBytes(w, e.key(), format)
+	return writelnBytes(w, e.Key(), format)
 }
 
 // PrintLeafItemKey writes the bytes of a leaf element's value.
@@ -593,7 +585,7 @@ func (cmd *PageItemCommand) PrintLeafItemValue(w io.Writer, pageBytes []byte, in
 	if err != nil {
 		return err
 	}
-	return writelnBytes(w, e.value(), format)
+	return writelnBytes(w, e.Value(), format)
 }
 
 // Usage returns the help message.
@@ -1574,79 +1566,6 @@ func isPrintable(s string) bool {
 	return true
 }
 
-// ReadPage reads page info & full page data from a path.
-// This is not transactionally safe.
-func ReadPage(path string, pageID uint64) (*page, []byte, error) {
-	// Find page size.
-	pageSize, hwm, err := ReadPageAndHWMSize(path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("read page size: %s", err)
-	}
-
-	// Open database file.
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer f.Close()
-
-	// Read one block into buffer.
-	buf := make([]byte, pageSize)
-	if n, err := f.ReadAt(buf, int64(pageID*pageSize)); err != nil {
-		return nil, nil, err
-	} else if n != len(buf) {
-		return nil, nil, io.ErrUnexpectedEOF
-	}
-
-	// Determine total number of blocks.
-	p := (*page)(unsafe.Pointer(&buf[0]))
-	if p.id != pgid(pageID) {
-		return nil, nil, fmt.Errorf("error: %w due to unexpected page id: %d != %d", ErrCorrupt, p.id, pageID)
-	}
-	overflowN := p.overflow
-	if overflowN >= uint32(hwm)-3 { // we exclude 2 meta pages and the current page.
-		return nil, nil, fmt.Errorf("error: %w, page claims to have %d overflow pages (>=hwm=%d). Interrupting to avoid risky OOM", ErrCorrupt, overflowN, hwm)
-	}
-
-	// Re-read entire page (with overflow) into buffer.
-	buf = make([]byte, (uint64(overflowN)+1)*pageSize)
-	if n, err := f.ReadAt(buf, int64(pageID*pageSize)); err != nil {
-		return nil, nil, err
-	} else if n != len(buf) {
-		return nil, nil, io.ErrUnexpectedEOF
-	}
-	p = (*page)(unsafe.Pointer(&buf[0]))
-	if p.id != pgid(pageID) {
-		return nil, nil, fmt.Errorf("error: %w due to unexpected page id: %d != %d", ErrCorrupt, p.id, pageID)
-	}
-
-	return p, buf, nil
-}
-
-// ReadPageAndHWMSize reads page size and HWM (id of the last+1 page).
-// This is not transactionally safe.
-func ReadPageAndHWMSize(path string) (uint64, pgid, error) {
-	// Open database file.
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, 0, err
-	}
-	defer f.Close()
-
-	// Read 4KB chunk.
-	buf := make([]byte, 4096)
-	if _, err := io.ReadFull(f, buf); err != nil {
-		return 0, 0, err
-	}
-
-	// Read page size from metadata.
-	m := (*meta)(unsafe.Pointer(&buf[PageHeaderSize]))
-	if m.magic != magic {
-		return 0, 0, fmt.Errorf("the meta page has wrong (unexpected) magic")
-	}
-	return uint64(m.pageSize), pgid(m.pgid), nil
-}
-
 func stringToPage(str string) (uint64, error) {
 	return strconv.ParseUint(str, 10, 64)
 }
@@ -1662,112 +1581,6 @@ func stringToPages(strs []string) ([]uint64, error) {
 		a = append(a, i)
 	}
 	return a, nil
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-const maxAllocSize = 0xFFFFFFF
-
-// DO NOT EDIT. Copied from the "bolt" package.
-const (
-	branchPageFlag   = 0x01
-	leafPageFlag     = 0x02
-	metaPageFlag     = 0x04
-	freelistPageFlag = 0x10
-)
-
-// DO NOT EDIT. Copied from the "bolt" package.
-const bucketLeafFlag = 0x01
-
-// DO NOT EDIT. Copied from the "bolt" package.
-type pgid uint64
-
-// DO NOT EDIT. Copied from the "bolt" package.
-type txid uint64
-
-// DO NOT EDIT. Copied from the "bolt" package.
-type meta struct {
-	magic    uint32
-	version  uint32
-	pageSize uint32
-	flags    uint32
-	root     bucket
-	freelist pgid
-	pgid     pgid // High Water Mark (id of next added page if the file growths)
-	txid     txid
-	checksum uint64
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-type bucket struct {
-	root     pgid
-	sequence uint64
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-type page struct {
-	id       pgid
-	flags    uint16
-	count    uint16
-	overflow uint32
-	ptr      uintptr
-}
-
-func (p *page) Type() string {
-	// For now all flags are exclusive,so let's be strict with expectations.
-	if p.flags == branchPageFlag {
-		return "branch"
-	} else if p.flags == leafPageFlag {
-		return "leaf"
-	} else if p.flags == metaPageFlag {
-		return "meta"
-	} else if p.flags == freelistPageFlag {
-		return "freelist"
-	}
-	return fmt.Sprintf("unknown<%02x>", p.flags)
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-func (p *page) leafPageElement(index uint16) *leafPageElement {
-	n := &((*[0x7FFFFFF]leafPageElement)(unsafe.Pointer(&p.ptr)))[index]
-	return n
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-func (p *page) branchPageElement(index uint16) *branchPageElement {
-	return &((*[0x7FFFFFF]branchPageElement)(unsafe.Pointer(&p.ptr)))[index]
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-type branchPageElement struct {
-	pos   uint32
-	ksize uint32
-	pgid  pgid
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-func (n *branchPageElement) key() []byte {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
-	return buf[n.pos : n.pos+n.ksize]
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-type leafPageElement struct {
-	flags uint32
-	pos   uint32
-	ksize uint32
-	vsize uint32
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-func (n *leafPageElement) key() []byte {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
-	return buf[n.pos : n.pos+n.ksize]
-}
-
-// DO NOT EDIT. Copied from the "bolt" package.
-func (n *leafPageElement) value() []byte {
-	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
-	return buf[n.pos+n.ksize : n.pos+n.ksize+n.vsize]
 }
 
 // CompactCommand represents the "compact" command execution.

--- a/cmd/bbolt/main_test.go
+++ b/cmd/bbolt/main_test.go
@@ -5,14 +5,16 @@ import (
 	crypto "crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"go.etcd.io/bbolt/internal/btesting"
 	"io"
 	"math/rand"
 	"os"
 	"strconv"
 	"testing"
 
+	"go.etcd.io/bbolt/internal/btesting"
+
 	"github.com/stretchr/testify/require"
+
 	bolt "go.etcd.io/bbolt"
 	main "go.etcd.io/bbolt/cmd/bbolt"
 )

--- a/cmd/bbolt/page_command.go
+++ b/cmd/bbolt/page_command.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"go.etcd.io/bbolt/internal/guts_cli"
 	"io"
 	"os"
 	"strings"
+
+	"go.etcd.io/bbolt/internal/guts_cli"
 )
 
 // PageCommand represents the "page" command execution.

--- a/cmd/bbolt/page_command.go
+++ b/cmd/bbolt/page_command.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"go.etcd.io/bbolt/internal/guts_cli"
 	"io"
 	"os"
 	"strings"
-	"unsafe"
 )
 
 // PageCommand represents the "page" command execution.
@@ -79,7 +79,7 @@ func (cmd *PageCommand) printPages(pageIDs []uint64, path string, formatValue *s
 }
 
 func (cmd *PageCommand) printAllPages(path string, formatValue *string) {
-	_, hwm, err := ReadPageAndHWMSize(path)
+	_, hwm, err := guts_cli.ReadPageAndHWMSize(path)
 	if err != nil {
 		fmt.Fprintf(cmd.Stdout, "cannot read number of pages: %v", err)
 	}
@@ -109,16 +109,16 @@ func (cmd *PageCommand) printPage(path string, pageID uint64, formatValue string
 	}()
 
 	// Retrieve page info and page size.
-	p, buf, err := ReadPage(path, pageID)
+	p, buf, err := guts_cli.ReadPage(path, pageID)
 	if err != nil {
 		return 0, err
 	}
 
 	// Print basic page info.
-	fmt.Fprintf(cmd.Stdout, "Page ID:    %d\n", p.id)
+	fmt.Fprintf(cmd.Stdout, "Page ID:    %d\n", p.Id())
 	fmt.Fprintf(cmd.Stdout, "Page Type:  %s\n", p.Type())
 	fmt.Fprintf(cmd.Stdout, "Total Size: %d bytes\n", len(buf))
-	fmt.Fprintf(cmd.Stdout, "Overflow pages: %d\n", p.overflow)
+	fmt.Fprintf(cmd.Stdout, "Overflow pages: %d\n", p.Overflow())
 
 	// Print type-specific data.
 	switch p.Type() {
@@ -134,52 +134,44 @@ func (cmd *PageCommand) printPage(path string, pageID uint64, formatValue string
 	if err != nil {
 		return 0, err
 	}
-	return p.overflow, nil
+	return p.Overflow(), nil
 }
 
 // PrintMeta prints the data from the meta page.
 func (cmd *PageCommand) PrintMeta(w io.Writer, buf []byte) error {
-	m := (*meta)(unsafe.Pointer(&buf[PageHeaderSize]))
-	fmt.Fprintf(w, "Version:    %d\n", m.version)
-	fmt.Fprintf(w, "Page Size:  %d bytes\n", m.pageSize)
-	fmt.Fprintf(w, "Flags:      %08x\n", m.flags)
-	fmt.Fprintf(w, "Root:       <pgid=%d>\n", m.root.root)
-	fmt.Fprintf(w, "Freelist:   <pgid=%d>\n", m.freelist)
-	fmt.Fprintf(w, "HWM:        <pgid=%d>\n", m.pgid)
-	fmt.Fprintf(w, "Txn ID:     %d\n", m.txid)
-	fmt.Fprintf(w, "Checksum:   %016x\n", m.checksum)
-	fmt.Fprintf(w, "\n")
+	m := guts_cli.LoadPageMeta(buf)
+	m.Print(w)
 	return nil
 }
 
 // PrintLeaf prints the data for a leaf page.
 func (cmd *PageCommand) PrintLeaf(w io.Writer, buf []byte, formatValue string) error {
-	p := (*page)(unsafe.Pointer(&buf[0]))
+	p := guts_cli.LoadPage(buf)
 
 	// Print number of items.
-	fmt.Fprintf(w, "Item Count: %d\n", p.count)
+	fmt.Fprintf(w, "Item Count: %d\n", p.Count())
 	fmt.Fprintf(w, "\n")
 
 	// Print each key/value.
-	for i := uint16(0); i < p.count; i++ {
-		e := p.leafPageElement(i)
+	for i := uint16(0); i < p.Count(); i++ {
+		e := p.LeafPageElement(i)
 
 		// Format key as string.
 		var k string
-		if isPrintable(string(e.key())) {
-			k = fmt.Sprintf("%q", string(e.key()))
+		if isPrintable(string(e.Key())) {
+			k = fmt.Sprintf("%q", string(e.Key()))
 		} else {
-			k = fmt.Sprintf("%x", string(e.key()))
+			k = fmt.Sprintf("%x", string(e.Key()))
 		}
 
 		// Format value as string.
 		var v string
-		if (e.flags & uint32(bucketLeafFlag)) != 0 {
-			b := (*bucket)(unsafe.Pointer(&e.value()[0]))
-			v = fmt.Sprintf("<pgid=%d,seq=%d>", b.root, b.sequence)
+		if e.IsBucketEntry() {
+			b := e.Bucket()
+			v = b.String()
 		} else {
 			var err error
-			v, err = formatBytes(e.value(), formatValue)
+			v, err = formatBytes(e.Value(), formatValue)
 			if err != nil {
 				return err
 			}
@@ -193,25 +185,25 @@ func (cmd *PageCommand) PrintLeaf(w io.Writer, buf []byte, formatValue string) e
 
 // PrintBranch prints the data for a leaf page.
 func (cmd *PageCommand) PrintBranch(w io.Writer, buf []byte) error {
-	p := (*page)(unsafe.Pointer(&buf[0]))
+	p := guts_cli.LoadPage(buf)
 
 	// Print number of items.
-	fmt.Fprintf(w, "Item Count: %d\n", p.count)
+	fmt.Fprintf(w, "Item Count: %d\n", p.Count())
 	fmt.Fprintf(w, "\n")
 
 	// Print each key/value.
-	for i := uint16(0); i < p.count; i++ {
-		e := p.branchPageElement(i)
+	for i := uint16(0); i < p.Count(); i++ {
+		e := p.BranchPageElement(i)
 
 		// Format key as string.
 		var k string
-		if isPrintable(string(e.key())) {
-			k = fmt.Sprintf("%q", string(e.key()))
+		if isPrintable(string(e.Key())) {
+			k = fmt.Sprintf("%q", string(e.Key()))
 		} else {
-			k = fmt.Sprintf("%x", string(e.key()))
+			k = fmt.Sprintf("%x", string(e.Key()))
 		}
 
-		fmt.Fprintf(w, "%s: <pgid=%d>\n", k, e.pgid)
+		fmt.Fprintf(w, "%s: <pgid=%d>\n", k, e.PgId())
 	}
 	fmt.Fprintf(w, "\n")
 	return nil
@@ -219,25 +211,18 @@ func (cmd *PageCommand) PrintBranch(w io.Writer, buf []byte) error {
 
 // PrintFreelist prints the data for a freelist page.
 func (cmd *PageCommand) PrintFreelist(w io.Writer, buf []byte) error {
-	p := (*page)(unsafe.Pointer(&buf[0]))
-
-	// Check for overflow and, if present, adjust starting index and actual element count.
-	idx, count := 0, int(p.count)
-	if p.count == 0xFFFF {
-		idx = 1
-		count = int(((*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr)))[0])
-	}
+	p := guts_cli.LoadPage(buf)
 
 	// Print number of items.
-	fmt.Fprintf(w, "Item Count: %d\n", count)
-	fmt.Fprintf(w, "Overflow: %d\n", p.overflow)
+	fmt.Fprintf(w, "Item Count: %d\n", p.FreelistPageCount())
+	fmt.Fprintf(w, "Overflow: %d\n", p.Overflow())
 
 	fmt.Fprintf(w, "\n")
 
 	// Print each page in the freelist.
-	ids := (*[maxAllocSize]pgid)(unsafe.Pointer(&p.ptr))
-	for i := idx; i < count; i++ {
-		fmt.Fprintf(w, "%d\n", ids[i])
+	ids := p.FreelistPagePages()
+	for _, ids := range ids {
+		fmt.Fprintf(w, "%d\n", ids)
 	}
 	fmt.Fprintf(w, "\n")
 	return nil

--- a/internal/guts_cli/guts_cli.go
+++ b/internal/guts_cli/guts_cli.go
@@ -1,0 +1,314 @@
+package guts_cli
+
+// Low level access to pages / data-structures of the bbolt file.
+
+// TODO(ptab): Merge with bbolt/page file that should get ported to internal.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"unsafe"
+)
+
+var (
+	// ErrCorrupt is returned when a checking a data file finds errors.
+	ErrCorrupt = errors.New("invalid value")
+)
+
+// PageHeaderSize represents the size of the bolt.Page header.
+const PageHeaderSize = 16
+
+// Represents a marker value to indicate that a file (Meta Page) is a Bolt DB.
+const magic uint32 = 0xED0CDAED
+
+// DO NOT EDIT. Copied from the "bolt" package.
+const maxAllocSize = 0xFFFFFFF
+
+// DO NOT EDIT. Copied from the "bolt" package.
+const (
+	branchPageFlag   = 0x01
+	leafPageFlag     = 0x02
+	metaPageFlag     = 0x04
+	freelistPageFlag = 0x10
+)
+
+// DO NOT EDIT. Copied from the "bolt" package.
+const bucketLeafFlag = 0x01
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type Pgid uint64
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type txid uint64
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type Meta struct {
+	magic    uint32
+	version  uint32
+	pageSize uint32
+	flags    uint32
+	root     Bucket
+	freelist Pgid
+	pgid     Pgid // High Water Mark (id of next added Page if the file growths)
+	txid     txid
+	checksum uint64
+}
+
+func LoadPageMeta(buf []byte) *Meta {
+	return (*Meta)(unsafe.Pointer(&buf[PageHeaderSize]))
+}
+
+func (m *Meta) RootBucket() *Bucket {
+	return &m.root
+}
+
+func (m *Meta) Print(w io.Writer) {
+	fmt.Fprintf(w, "Version:    %d\n", m.version)
+	fmt.Fprintf(w, "Page Size:  %d bytes\n", m.pageSize)
+	fmt.Fprintf(w, "Flags:      %08x\n", m.flags)
+	fmt.Fprintf(w, "Root:       <pgid=%d>\n", m.root.root)
+	fmt.Fprintf(w, "Freelist:   <pgid=%d>\n", m.freelist)
+	fmt.Fprintf(w, "HWM:        <pgid=%d>\n", m.pgid)
+	fmt.Fprintf(w, "Txn ID:     %d\n", m.txid)
+	fmt.Fprintf(w, "Checksum:   %016x\n", m.checksum)
+	fmt.Fprintf(w, "\n")
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type Bucket struct {
+	root     Pgid
+	sequence uint64
+}
+
+const bucketHeaderSize = int(unsafe.Sizeof(Bucket{}))
+
+func LoadBucket(buf []byte) *Bucket {
+	return (*Bucket)(unsafe.Pointer(&buf[0]))
+}
+
+func (b *Bucket) String() string {
+	return fmt.Sprintf("<pgid=%d,seq=%d>", b.root, b.sequence)
+}
+
+func (b *Bucket) RootPage() Pgid {
+	return b.root
+}
+
+func (b *Bucket) InlinePage(v []byte) *Page {
+	return (*Page)(unsafe.Pointer(&v[bucketHeaderSize]))
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type Page struct {
+	id       Pgid
+	flags    uint16
+	count    uint16
+	overflow uint32
+	ptr      uintptr
+}
+
+func LoadPage(buf []byte) *Page {
+	return (*Page)(unsafe.Pointer(&buf[0]))
+}
+
+func (p *Page) FreelistPageCount() int {
+	// Check for overflow and, if present, adjust actual element count.
+	if p.count == 0xFFFF {
+		return int(((*[maxAllocSize]Pgid)(unsafe.Pointer(&p.ptr)))[0])
+	} else {
+		return int(p.count)
+	}
+}
+
+func (p *Page) FreelistPagePages() []Pgid {
+	// Check for overflow and, if present, adjust starting index.
+	idx := 0
+	if p.count == 0xFFFF {
+		idx = 1
+	}
+	return (*[maxAllocSize]Pgid)(unsafe.Pointer(&p.ptr))[idx:p.FreelistPageCount()]
+}
+
+func (p *Page) Overflow() uint32 {
+	return p.overflow
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (p *Page) Type() string {
+	if (p.flags & branchPageFlag) != 0 {
+		return "branch"
+	} else if (p.flags & leafPageFlag) != 0 {
+		return "leaf"
+	} else if (p.flags & metaPageFlag) != 0 {
+		return "Meta"
+	} else if (p.flags & freelistPageFlag) != 0 {
+		return "freelist"
+	}
+	return fmt.Sprintf("unknown<%02x>", p.flags)
+}
+
+func (p *Page) Count() uint16 {
+	return p.count
+}
+
+func (p *Page) Id() Pgid {
+	return p.id
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (p *Page) LeafPageElement(index uint16) *LeafPageElement {
+	n := &((*[0x7FFFFFF]LeafPageElement)(unsafe.Pointer(&p.ptr)))[index]
+	return n
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (p *Page) BranchPageElement(index uint16) *BranchPageElement {
+	return &((*[0x7FFFFFF]BranchPageElement)(unsafe.Pointer(&p.ptr)))[index]
+}
+
+func (p *Page) SetId(target Pgid) {
+	p.id = target
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type BranchPageElement struct {
+	pos   uint32
+	ksize uint32
+	pgid  Pgid
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (n *BranchPageElement) Key() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return buf[n.pos : n.pos+n.ksize]
+}
+
+func (n *BranchPageElement) PgId() Pgid {
+	return n.pgid
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+type LeafPageElement struct {
+	flags uint32
+	pos   uint32
+	ksize uint32
+	vsize uint32
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (n *LeafPageElement) Key() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return buf[n.pos : n.pos+n.ksize]
+}
+
+// DO NOT EDIT. Copied from the "bolt" package.
+func (n *LeafPageElement) Value() []byte {
+	buf := (*[maxAllocSize]byte)(unsafe.Pointer(n))
+	return buf[n.pos+n.ksize : n.pos+n.ksize+n.vsize]
+}
+
+func (n *LeafPageElement) IsBucketEntry() bool {
+	return n.flags&uint32(bucketLeafFlag) != 0
+}
+
+func (n *LeafPageElement) Bucket() *Bucket {
+	if n.IsBucketEntry() {
+		return LoadBucket(n.Value())
+	} else {
+		return nil
+	}
+}
+
+// ReadPage reads Page info & full Page data from a path.
+// This is not transactionally safe.
+func ReadPage(path string, pageID uint64) (*Page, []byte, error) {
+	// Find Page size.
+	pageSize, hwm, err := ReadPageAndHWMSize(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read Page size: %s", err)
+	}
+
+	// Open database file.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	// Read one block into buffer.
+	buf := make([]byte, pageSize)
+	if n, err := f.ReadAt(buf, int64(pageID*pageSize)); err != nil {
+		return nil, nil, err
+	} else if n != len(buf) {
+		return nil, nil, io.ErrUnexpectedEOF
+	}
+
+	// Determine total number of blocks.
+	p := LoadPage(buf)
+	if p.id != Pgid(pageID) {
+		return nil, nil, fmt.Errorf("error: %w due to unexpected Page id: %d != %d", ErrCorrupt, p.id, pageID)
+	}
+	overflowN := p.overflow
+	if overflowN >= uint32(hwm)-3 { // we exclude 2 Meta pages and the current Page.
+		return nil, nil, fmt.Errorf("error: %w, Page claims to have %d overflow pages (>=hwm=%d). Interrupting to avoid risky OOM", ErrCorrupt, overflowN, hwm)
+	}
+
+	// Re-read entire Page (with overflow) into buffer.
+	buf = make([]byte, (uint64(overflowN)+1)*pageSize)
+	if n, err := f.ReadAt(buf, int64(pageID*pageSize)); err != nil {
+		return nil, nil, err
+	} else if n != len(buf) {
+		return nil, nil, io.ErrUnexpectedEOF
+	}
+	p = LoadPage(buf)
+	if p.id != Pgid(pageID) {
+		return nil, nil, fmt.Errorf("error: %w due to unexpected Page id: %d != %d", ErrCorrupt, p.id, pageID)
+	}
+
+	return p, buf, nil
+}
+
+// ReadPageAndHWMSize reads Page size and HWM (id of the last+1 Page).
+// This is not transactionally safe.
+func ReadPageAndHWMSize(path string) (uint64, Pgid, error) {
+	// Open database file.
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer f.Close()
+
+	// Read 4KB chunk.
+	buf := make([]byte, 4096)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		return 0, 0, err
+	}
+
+	// Read Page size from metadata.
+	m := LoadPageMeta(buf)
+	if m.magic != magic {
+		return 0, 0, fmt.Errorf("the Meta Page has wrong (unexpected) magic")
+	}
+	return uint64(m.pageSize), Pgid(m.pgid), nil
+}
+
+// GetRootPage returns the root-page (according to the most recent transaction).
+func GetRootPage(path string) (root Pgid, activeMeta Pgid, err error) {
+	_, buf0, err0 := ReadPage(path, 0)
+	if err0 != nil {
+		return 0, 0, err0
+	}
+	m0 := LoadPageMeta(buf0)
+	_, buf1, err1 := ReadPage(path, 1)
+	if err1 != nil {
+		return 0, 1, err1
+	}
+	m1 := LoadPageMeta(buf1)
+	if m0.txid < m1.txid {
+		return m1.root.root, 1, nil
+	} else {
+		return m0.root.root, 0, nil
+	}
+}

--- a/internal/guts_cli/guts_cli.go
+++ b/internal/guts_cli/guts_cli.go
@@ -136,6 +136,8 @@ func (p *Page) Overflow() uint32 {
 }
 
 // DO NOT EDIT. Copied from the "bolt" package.
+
+// TODO(ptabor): Make the page-types an enum.
 func (p *Page) Type() string {
 	if (p.flags & branchPageFlag) != 0 {
 		return "branch"

--- a/internal/guts_cli/guts_cli.go
+++ b/internal/guts_cli/guts_cli.go
@@ -142,7 +142,7 @@ func (p *Page) Type() string {
 	} else if (p.flags & leafPageFlag) != 0 {
 		return "leaf"
 	} else if (p.flags & metaPageFlag) != 0 {
-		return "Meta"
+		return "meta"
 	} else if (p.flags & freelistPageFlag) != 0 {
 		return "freelist"
 	}

--- a/internal/surgeon/surgeon.go
+++ b/internal/surgeon/surgeon.go
@@ -1,0 +1,50 @@
+package surgeon
+
+import (
+	"fmt"
+	"go.etcd.io/bbolt/internal/guts_cli"
+	"os"
+)
+
+func CopyPage(path string, srcPage guts_cli.Pgid, target guts_cli.Pgid) error {
+	p1, d1, err1 := guts_cli.ReadPage(path, uint64(srcPage))
+	if err1 != nil {
+		return err1
+	}
+	p1.SetId(target)
+	return WritePage(path, d1)
+}
+
+func WritePage(path string, pageBuf []byte) error {
+	page := guts_cli.LoadPage(pageBuf)
+	pageSize, _, err := guts_cli.ReadPageAndHWMSize(path)
+	if err != nil {
+		return err
+	}
+	if pageSize != uint64(len(pageBuf)) {
+		return fmt.Errorf("WritePage: len(buf)=%d != pageSize=%d", len(pageBuf), pageSize)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteAt(pageBuf, int64(page.Id())*int64(pageSize))
+	return err
+}
+
+// RevertMetaPage replaces the newer metadata page with the older.
+// It usually means that one transaction is being lost. But frequently
+// data corruption happens on the last transaction pages and the
+// previous state is consistent.
+func RevertMetaPage(path string) error {
+	_, activeMetaPage, err := guts_cli.GetRootPage(path)
+	if err != nil {
+		return err
+	}
+	if activeMetaPage == 0 {
+		return CopyPage(path, 1, 0)
+	} else {
+		return CopyPage(path, 0, 1)
+	}
+}

--- a/internal/surgeon/surgeon.go
+++ b/internal/surgeon/surgeon.go
@@ -2,8 +2,9 @@ package surgeon
 
 import (
 	"fmt"
-	"go.etcd.io/bbolt/internal/guts_cli"
 	"os"
+
+	"go.etcd.io/bbolt/internal/guts_cli"
 )
 
 func CopyPage(path string, srcPage guts_cli.Pgid, target guts_cli.Pgid) error {

--- a/internal/surgeon/surgeon_test.go
+++ b/internal/surgeon/surgeon_test.go
@@ -1,0 +1,55 @@
+package surgeon_test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/bbolt/internal/btesting"
+	"go.etcd.io/bbolt/internal/surgeon"
+	"testing"
+)
+
+func TestRevertMetaPage(t *testing.T) {
+	db := btesting.MustCreateDB(t)
+	assert.NoError(t,
+		db.Fill([]byte("data"), 1, 500,
+			func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
+			func(tx int, k int) []byte { return make([]byte, 100) },
+		))
+	assert.NoError(t,
+		db.Update(
+			func(tx *bolt.Tx) error {
+				b := tx.Bucket([]byte("data"))
+				assert.NoError(t, b.Put([]byte("0123"), []byte("new Value for 123")))
+				assert.NoError(t, b.Put([]byte("1234b"), []byte("additional object")))
+				assert.NoError(t, b.Delete([]byte("0246")))
+				return nil
+			}))
+
+	assert.NoError(t,
+		db.View(
+			func(tx *bolt.Tx) error {
+				b := tx.Bucket([]byte("data"))
+				assert.Equal(t, []byte("new Value for 123"), b.Get([]byte("0123")))
+				assert.Equal(t, []byte("additional object"), b.Get([]byte("1234b")))
+				assert.Nil(t, b.Get([]byte("0246")))
+				return nil
+			}))
+
+	db.Close()
+
+	// This causes the whole tree to be linked to the previous state
+	assert.NoError(t, surgeon.RevertMetaPage(db.Path()))
+
+	db.MustReopen()
+	db.MustCheck()
+	assert.NoError(t,
+		db.View(
+			func(tx *bolt.Tx) error {
+				b := tx.Bucket([]byte("data"))
+				assert.Equal(t, make([]byte, 100), b.Get([]byte("0123")))
+				assert.Nil(t, b.Get([]byte("1234b")))
+				assert.Equal(t, make([]byte, 100), b.Get([]byte("0246")))
+				return nil
+			}))
+}

--- a/internal/surgeon/surgeon_test.go
+++ b/internal/surgeon/surgeon_test.go
@@ -2,11 +2,13 @@ package surgeon_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
+
 	bolt "go.etcd.io/bbolt"
 	"go.etcd.io/bbolt/internal/btesting"
 	"go.etcd.io/bbolt/internal/surgeon"
-	"testing"
 )
 
 func TestRevertMetaPage(t *testing.T) {

--- a/internal/surgeon/xray.go
+++ b/internal/surgeon/xray.go
@@ -69,9 +69,9 @@ func (n XRay) traverseInternal(stack []guts_cli.Pgid, callback func(page *guts_c
 	return nil
 }
 
-// FindPathToPagesWithKey finds a path (from root to the page that contains the given key.
-// As it traverses multiple buckets, in theory there might be multiple keys with given name.
-// Note: For simplicity it's currently implemented as traversing whole reachable tree.
+// FindPathToPagesWithKey finds all paths from root to the page that contains the given key.
+// As it traverses multiple buckets, so in theory there might be multiple keys with the given name.
+// Note: For simplicity it's currently implemented as traversing of the whole reachable tree.
 func (n XRay) FindPathToPagesWithKey(key []byte) ([][]guts_cli.Pgid, error) {
 	var found [][]guts_cli.Pgid
 

--- a/internal/surgeon/xray.go
+++ b/internal/surgeon/xray.go
@@ -1,0 +1,99 @@
+package surgeon
+
+// Library contains raw access to bbolt files for sake of testing or fixing of corrupted files.
+//
+// The library must not be used bbolt btree - just by CLI or tests.
+// It's not optimized for performance.
+
+import (
+	"bytes"
+	"fmt"
+	"go.etcd.io/bbolt/internal/guts_cli"
+)
+
+type XRay struct {
+	path string
+}
+
+func NewXRay(path string) XRay {
+	return XRay{path}
+}
+
+func (n XRay) traverseInternal(stack []guts_cli.Pgid, callback func(page *guts_cli.Page, stack []guts_cli.Pgid) error) error {
+	p, data, err := guts_cli.ReadPage(n.path, uint64(stack[len(stack)-1]))
+	if err != nil {
+		return fmt.Errorf("failed reading page (stack %v): %w", stack, err)
+	}
+	err = callback(p, stack)
+	if err != nil {
+		return fmt.Errorf("failed callback for page (stack %v): %w", stack, err)
+	}
+	switch p.Type() {
+	case "meta":
+		{
+			m := guts_cli.LoadPageMeta(data)
+			r := m.RootBucket().RootPage()
+			return n.traverseInternal(append(stack, r), callback)
+		}
+	case "branch":
+		{
+			for i := uint16(0); i < p.Count(); i++ {
+				bpe := p.BranchPageElement(i)
+				if err := n.traverseInternal(append(stack, bpe.PgId()), callback); err != nil {
+					return err
+				}
+			}
+		}
+	case "leaf":
+		for i := uint16(0); i < p.Count(); i++ {
+			lpe := p.LeafPageElement(i)
+			if lpe.IsBucketEntry() {
+				pgid := lpe.Bucket().RootPage()
+				if pgid > 0 {
+					if err := n.traverseInternal(append(stack, pgid), callback); err != nil {
+						return err
+					}
+				} else {
+					inlinePage := lpe.Bucket().InlinePage(lpe.Value())
+					if err := callback(inlinePage, stack); err != nil {
+						return fmt.Errorf("failed callback for inline page  (stack %v): %w", stack, err)
+					}
+				}
+			}
+		}
+	case "freelist":
+		return nil
+		// Free does not have children.
+	}
+	return nil
+}
+
+// FindPathToPagesWithKey finds a path (from root to the page that contains the given key.
+// As it traverses multiple buckets, in theory there might be multiple keys with given name.
+// Note: For simplicity it's currently implemented as traversing whole reachable tree.
+func (n XRay) FindPathToPagesWithKey(key []byte) ([][]guts_cli.Pgid, error) {
+	var found [][]guts_cli.Pgid
+
+	rootPage, _, err := guts_cli.GetRootPage(n.path)
+	if err != nil {
+		return nil, err
+	}
+	err = n.traverseInternal([]guts_cli.Pgid{rootPage},
+		func(page *guts_cli.Page, stack []guts_cli.Pgid) error {
+			if page.Type() == "leaf" {
+				for i := uint16(0); i < page.Count(); i++ {
+					if bytes.Equal(page.LeafPageElement(i).Key(), key) {
+						var copyPath []guts_cli.Pgid
+						copyPath = append(copyPath, stack...)
+						found = append(found, copyPath)
+					}
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, err
+	} else {
+		return found, nil
+	}
+}

--- a/internal/surgeon/xray.go
+++ b/internal/surgeon/xray.go
@@ -8,6 +8,7 @@ package surgeon
 import (
 	"bytes"
 	"fmt"
+
 	"go.etcd.io/bbolt/internal/guts_cli"
 )
 

--- a/internal/surgeon/xray_test.go
+++ b/internal/surgeon/xray_test.go
@@ -2,11 +2,13 @@ package surgeon_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/bbolt/internal/btesting"
 	"go.etcd.io/bbolt/internal/guts_cli"
 	"go.etcd.io/bbolt/internal/surgeon"
-	"testing"
 )
 
 func TestNavigator_FindPathToPagesWithKey(t *testing.T) {

--- a/internal/surgeon/xray_test.go
+++ b/internal/surgeon/xray_test.go
@@ -1,0 +1,31 @@
+package surgeon_test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/bbolt/internal/btesting"
+	"go.etcd.io/bbolt/internal/guts_cli"
+	"go.etcd.io/bbolt/internal/surgeon"
+	"testing"
+)
+
+func TestNavigator_FindPathToPagesWithKey(t *testing.T) {
+	db := btesting.MustCreateDB(t)
+	assert.NoError(t,
+		db.Fill([]byte("data"), 1, 500,
+			func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
+			func(tx int, k int) []byte { return make([]byte, 100) },
+		))
+	assert.NoError(t, db.Close())
+
+	navigator := surgeon.NewXRay(db.Path())
+	path1, err := navigator.FindPathToPagesWithKey([]byte("0451"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, path1)
+
+	page := path1[0][len(path1[0])-1]
+	p, _, err := guts_cli.ReadPage(db.Path(), uint64(page))
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, []byte("0451"), p.LeafPageElement(0).Key())
+	assert.LessOrEqual(t, []byte("0451"), p.LeafPageElement(p.Count()-1).Key())
+}

--- a/internal/surgeon/xray_test.go
+++ b/internal/surgeon/xray_test.go
@@ -5,13 +5,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"go.etcd.io/bbolt"
 	"go.etcd.io/bbolt/internal/btesting"
 	"go.etcd.io/bbolt/internal/guts_cli"
 	"go.etcd.io/bbolt/internal/surgeon"
 )
 
-func TestNavigator_FindPathToPagesWithKey(t *testing.T) {
+func TestFindPathsToKey(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 	assert.NoError(t,
 		db.Fill([]byte("data"), 1, 500,
@@ -21,7 +23,7 @@ func TestNavigator_FindPathToPagesWithKey(t *testing.T) {
 	assert.NoError(t, db.Close())
 
 	navigator := surgeon.NewXRay(db.Path())
-	path1, err := navigator.FindPathToPagesWithKey([]byte("0451"))
+	path1, err := navigator.FindPathsToKey([]byte("0451"))
 	assert.NoError(t, err)
 	assert.NotEmpty(t, path1)
 
@@ -30,4 +32,35 @@ func TestNavigator_FindPathToPagesWithKey(t *testing.T) {
 	assert.NoError(t, err)
 	assert.GreaterOrEqual(t, []byte("0451"), p.LeafPageElement(0).Key())
 	assert.LessOrEqual(t, []byte("0451"), p.LeafPageElement(p.Count()-1).Key())
+}
+
+func TestFindPathsToKey_Bucket(t *testing.T) {
+	rootBucket := []byte("data")
+	subBucket := []byte("0451A")
+
+	db := btesting.MustCreateDB(t)
+	assert.NoError(t,
+		db.Fill(rootBucket, 1, 500,
+			func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
+			func(tx int, k int) []byte { return make([]byte, 100) },
+		))
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		sb, err := tx.Bucket(rootBucket).CreateBucket(subBucket)
+		require.NoError(t, err)
+		require.NoError(t, sb.Put([]byte("foo"), []byte("bar")))
+		return nil
+	}))
+
+	assert.NoError(t, db.Close())
+
+	navigator := surgeon.NewXRay(db.Path())
+	path1, err := navigator.FindPathsToKey(subBucket)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, path1)
+
+	page := path1[0][len(path1[0])-1]
+	p, _, err := guts_cli.ReadPage(db.Path(), uint64(page))
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, subBucket, p.LeafPageElement(0).Key())
+	assert.LessOrEqual(t, subBucket, p.LeafPageElement(p.Count()-1).Key())
 }

--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go list  --f '{{with $d:=.}}{{range .GoFiles}}{{$d.Dir}}/{{.}}{{"\n"}}{{end}}{{end}}' ./... | xargs go run golang.org/x/tools/cmd/goimports@latest -w -local go.etcd.io

--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -1,3 +1,10 @@
-#!/bin/bash
+GO_CMD="go"
 
-go list  --f '{{with $d:=.}}{{range .GoFiles}}{{$d.Dir}}/{{.}}{{"\n"}}{{end}}{{end}}' ./... | xargs go run golang.org/x/tools/cmd/goimports@latest -w -local go.etcd.io
+GOFILES=$(${GO_CMD} list  --f "{{with \$d:=.}}{{range .GoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
+TESTGOFILES=$(${GO_CMD} list  --f "{{with \$d:=.}}{{range .TestGoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
+XTESTGOFILES=$(${GO_CMD} list  --f "{{with \$d:=.}}{{range .XTestGoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
+
+
+echo "${GOFILES}" "${TESTGOFILES}" "${XTESTGOFILES}"| xargs -n 100 go run golang.org/x/tools/cmd/goimports@latest -w -local go.etcd.io
+
+go fmt ./...

--- a/scripts/fix.sh
+++ b/scripts/fix.sh
@@ -1,5 +1,7 @@
 GO_CMD="go"
 
+# TODO(ptabor): Expand to cover different architectures (GOOS GOARCH), or just list go files.
+
 GOFILES=$(${GO_CMD} list  --f "{{with \$d:=.}}{{range .GoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
 TESTGOFILES=$(${GO_CMD} list  --f "{{with \$d:=.}}{{range .TestGoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)
 XTESTGOFILES=$(${GO_CMD} list  --f "{{with \$d:=.}}{{range .XTestGoFiles}}{{\$d.Dir}}/{{.}}{{\"\n\"}}{{end}}{{end}}" ./...)


### PR DESCRIPTION
This PR is:
 - on top of: https://github.com/etcd-io/bbolt/pull/360 
 - dependency of: https://github.com/etcd-io/bbolt/pull/225 

Please read it commit by commit: 
 - "factor out bolt->testing is irrelevant" (part of #360)
 - "factor out low-level access" is kind of mechanical move to a separate file. Some getters got added.
 - "Add library" is convenient abstraction layer and tests for future use.