### PR TITLE
Add protection when `mmap` somehow fails

### DIFF
--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -107,8 +107,11 @@ func munmap(db *DB) error {
 	}
 
 	addr := (uintptr)(unsafe.Pointer(&db.data[0]))
+	var err1 error
 	if err := syscall.UnmapViewOfFile(addr); err != nil {
-		return os.NewSyscallError("UnmapViewOfFile", err)
+		err1 = os.NewSyscallError("UnmapViewOfFile", err)
 	}
-	return nil
+	db.data = nil
+	db.datasz = 0
+	return err1
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1331,9 +1331,8 @@ func TestDBUnmap(t *testing.T) {
 	assert.True(t, data.IsNil())
 	assert.True(t, datasz.IsZero())
 
-	// We need to reopen the db, otherwise MustCheck may panic.
+	// Set db.DB to nil to prevent MustCheck from panicking.
 	db.DB = nil
-	db.MustReopen()
 }
 
 func ExampleDB_Update() {

--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,9 @@ var (
 	// This typically occurs when a file is not a bolt database.
 	ErrInvalid = errors.New("invalid database")
 
+	// ErrInvalidMapping is returned when the database file fails to get mapped.
+	ErrInvalidMapping = errors.New("database isn't correctly mapped")
+
 	// ErrVersionMismatch is returned when the data file was created with a
 	// different version of Bolt.
 	ErrVersionMismatch = errors.New("version mismatch")


### PR DESCRIPTION
Provent bbolt from panicking in case https://github.com/etcd-io/bbolt/issues/262

In `(*DB) mmap`, it `munmap` the file firstly, then `mmap` it again. If the `munmap` somehow fails, then the `db.data` is reset to `nil`. In this case, there is no need to execute `rollback`.

Signed-off-by: Benjamin Wang <wachao@vmware.com>