### PR TITLE
RO db should allow access to tx.Page(...) thus bbolt pages

### DIFF
--- a/db.go
+++ b/db.go
@@ -281,6 +281,8 @@ func Open(path string, mode os.FileMode, options *Options) (*DB, error) {
 		return db, nil
 	}
 
+	// TODO(ptabor): Introduce bbolt.option to load freepages even in RO transactions,
+	// such that debugging tools (bbolt CLI) can distinguish whether page is reachable or not.
 	db.loadFreelist()
 
 	// Flush freelist when transitioning from no sync to sync so

--- a/tx.go
+++ b/tx.go
@@ -660,10 +660,17 @@ func (tx *Tx) Page(id int) (*PageInfo, error) {
 	}
 
 	// Determine the type (or if it's free).
-	if tx.db.freelist.freed(pgid(id)) {
-		info.Type = "free"
+	if tx.db.freelist != nil {
+		if tx.db.freelist.freed(pgid(id)) {
+			info.Type = "free"
+		} else {
+			info.Type = p.typ()
+		}
 	} else {
-		info.Type = p.typ()
+		// If DB is open in RO mode, we might not have freelist available.
+		// So we cannot distinguish whether page is free or not.
+		// TODO(ptabor): Introduce bbolt.option to load freepages even in RO.
+		info.Type = p.typ() + "?"
 	}
 
 	return info, nil


### PR DESCRIPTION
I discoved that after change https://github.com/etcd-io/bbolt/pull/365 the 'bbolt pages' command stopped working.

The problem is this check:
https://github.com/etcd-io/bbolt/blob/b654ce922133ff49bb385297f30835ca357bac5f/tx.go#L663 that assumes that freepages has been loaded.

We can either preload the freepages when opening a RO file:
  https://github.com/etcd-io/bbolt/blob/b654ce922133ff49bb385297f30835ca357bac5f/db.go#L280-L284
but this would slow-down opening RO files.

Thus for now I disable checking whether page is free...

Signed-off-by: Piotr Tabor <ptab@google.com>