### PR TITLE
fix data race on tx.Stats

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,9 @@ jobs:
       fail-fast: false
       matrix:
         target:
-        - linux-amd64-unit-test-2-cpu
         - linux-amd64-unit-test-4-cpu
-        - linux-amd64-unit-test-4-cpu-race
+        - linux-amd64-unit-test-4-cpu-freelist-hashmap-race
+        - linux-amd64-unit-test-2-cpu-freelist-array-short-race
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -20,17 +20,14 @@ jobs:
         TARGET: ${{ matrix.target }}
       run: |
         case "${TARGET}" in
-          linux-amd64-unit-test-2-cpu)
-            CPU=2 make test-simulate
-            CPU=2 make test
-            ;;
           linux-amd64-unit-test-4-cpu)
-            CPU=4 make test-simulate
             CPU=4 make test
             ;;
-          linux-amd64-unit-test-4-cpu-race)
-            CPU=4 ENABLE_RACE=true make test-simulate
-            CPU=4 ENABLE_RACE=true make test
+          linux-amd64-unit-test-4-cpu-freelist-hashmap-race)
+            CPU=4 ENABLE_RACE=true make test-freelist-hashmap
+            ;;
+          linux-amd64-unit-test-2-cpu-freelist-array-short-race)
+            CPU=2 ENABLE_RACE=true EXTRA_TESTFLAGS="-short" make test-freelist-array
             ;;
           *)
             echo "Failed to find target"
@@ -66,7 +63,6 @@ jobs:
       run: |
         case "${TARGET}" in
           windows-amd64-unit-test-4-cpu)
-            CPU=4 make test-simulate
             CPU=4 make test
             ;;
           *)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,8 +3,13 @@ on: [push, pull_request]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        target:
+        - unit-test-2-cpu
+        - unit-test-4-cpu
+        - unit-test-4-cpu-race
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -12,7 +17,28 @@ jobs:
       with:
         go-version: "1.17.13"
     - run: make fmt
-    - run: make race
-    - run: make test
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        case "${TARGET}" in
+          unit-test-2-cpu)
+            CPU=2 make test-simulate
+            CPU=2 make test
+            ;;
+          unit-test-4-cpu)
+            CPU=4 make test-simulate
+            CPU=4 make test
+            ;;
+          unit-test-4-cpu-race)
+            CPU=4 ENABLE_RACE=true make test-simulate
+            CPU=4 ENABLE_RACE=true make test
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac
+      shell: bash
+    - run: make coverage
     - name: golangci-lint
       uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,16 +1,15 @@
 name: Tests
 on: [push, pull_request]
 jobs:
-  test:
+  test-linux:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
         target:
-        - unit-test-2-cpu
-        - unit-test-4-cpu
-        - unit-test-4-cpu-race
-    runs-on: ${{ matrix.os }}
+        - linux-amd64-unit-test-2-cpu
+        - linux-amd64-unit-test-4-cpu
+        - linux-amd64-unit-test-4-cpu-race
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
@@ -21,17 +20,54 @@ jobs:
         TARGET: ${{ matrix.target }}
       run: |
         case "${TARGET}" in
-          unit-test-2-cpu)
+          linux-amd64-unit-test-2-cpu)
             CPU=2 make test-simulate
             CPU=2 make test
             ;;
-          unit-test-4-cpu)
+          linux-amd64-unit-test-4-cpu)
             CPU=4 make test-simulate
             CPU=4 make test
             ;;
-          unit-test-4-cpu-race)
+          linux-amd64-unit-test-4-cpu-race)
             CPU=4 ENABLE_RACE=true make test-simulate
             CPU=4 ENABLE_RACE=true make test
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
+
+  test-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - windows-amd64-unit-test-4-cpu
+        # FIXME(fuweid):
+        #
+        # The windows will throws the following error when enable race.
+        # We skip it until we have solution.
+        #
+        #   ThreadSanitizer failed to allocate 0x000200000000 (8589934592) bytes at 0x0400c0000000 (error code: 1455)
+        #
+        #- windows-amd64-unit-test-4-cpu-race
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: "1.17.13"
+    - run: make fmt
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        case "${TARGET}" in
+          windows-amd64-unit-test-4-cpu)
+            CPU=4 make test-simulate
+            CPU=4 make test
             ;;
           *)
             echo "Failed to find target"
@@ -43,7 +79,7 @@ jobs:
       uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
 
   coverage:
-    needs: ["test"]
+    needs: ["test-linux", "test-windows"]
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,6 +39,19 @@ jobs:
             ;;
         esac
       shell: bash
-    - run: make coverage
     - name: golangci-lint
       uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 # v3.3.1
+
+  coverage:
+    needs: ["test"]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
+      with:
+        go-version: "1.17.13"
+    - run: make coverage
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.swp
 /bin/
 cover.out
+cover-*.out
 /.idea
 *.iml

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ TESTFLAGS_CPU=
 ifdef CPU
 	TESTFLAGS_CPU=-cpu=$(CPU)
 endif
-
-TESTFLAGS = $(TESTFLAGS_RACE) $(TESTFLAGS_CPU)
+TESTFLAGS = $(TESTFLAGS_RACE) $(TESTFLAGS_CPU) $(EXTRA_TESTFLAGS)
 
 fmt:
 	!(gofmt -l -s -d $(shell find . -name \*.go) | grep '[a-z]')
@@ -20,21 +19,17 @@ fmt:
 lint:
 	golangci-lint run ./...
 
-test:
+test: test-freelist-hashmap test-freelist-array
+
+test-freelist-hashmap:
 	@echo "hashmap freelist test"
 	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout 30m
 	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./cmd/bbolt
 
+test-freelist-array:
 	@echo "array freelist test"
 	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout 30m
 	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./cmd/bbolt
-
-test-simulate:
-	@echo "hashmap freelist test"
-	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -test.run="TestSimulate_(100op|1000op)"
-
-	@echo "array freelist test"
-	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -test.run="TestSimulate_(100op|1000op)"
 
 coverage:
 	@echo "hashmap freelist test"
@@ -45,4 +40,4 @@ coverage:
 	TEST_FREELIST_TYPE=array go test -v -timeout 30m \
 		-coverprofile cover-freelist-array.out -covermode atomic
 
-.PHONY: fmt test test-simulate lint
+.PHONY: fmt test test-freelist-hashmap test-freelist-array lint

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,17 @@ BRANCH=`git rev-parse --abbrev-ref HEAD`
 COMMIT=`git rev-parse --short HEAD`
 GOLDFLAGS="-X main.branch $(BRANCH) -X main.commit $(COMMIT)"
 
-race:
-	@TEST_FREELIST_TYPE=hashmap go test -v -race -test.run="TestSimulate_(100op|1000op)"
-	@echo "array freelist test"
-	@TEST_FREELIST_TYPE=array go test -v -race -test.run="TestSimulate_(100op|1000op)"
+TESTFLAGS_RACE=-race=false
+ifdef ENABLE_RACE
+	TESTFLAGS_RACE=-race=true
+endif
+
+TESTFLAGS_CPU=
+ifdef CPU
+	TESTFLAGS_CPU=-cpu=$(CPU)
+endif
+
+TESTFLAGS = $(TESTFLAGS_RACE) $(TESTFLAGS_CPU)
 
 fmt:
 	!(gofmt -l -s -d $(shell find . -name \*.go) | grep '[a-z]')
@@ -14,12 +21,28 @@ lint:
 	golangci-lint run ./...
 
 test:
-	TEST_FREELIST_TYPE=hashmap go test -timeout 30m -v -coverprofile cover.out -covermode atomic
-	TEST_FREELIST_TYPE=hashmap go test -v ./cmd/bbolt
+	@echo "hashmap freelist test"
+	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout 30m
+	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./cmd/bbolt
 
 	@echo "array freelist test"
+	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout 30m
+	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./cmd/bbolt
 
-	@TEST_FREELIST_TYPE=array go test -timeout 30m -v -coverprofile cover.out -covermode atomic
-	@TEST_FREELIST_TYPE=array go test -v ./cmd/bbolt
+test-simulate:
+	@echo "hashmap freelist test"
+	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -test.run="TestSimulate_(100op|1000op)"
 
-.PHONY: race fmt test lint
+	@echo "array freelist test"
+	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -test.run="TestSimulate_(100op|1000op)"
+
+coverage:
+	@echo "hashmap freelist test"
+	TEST_FREELIST_TYPE=hashmap go test -v -timeout 30m \
+		-coverprofile cover-freelist-hashmap.out -covermode atomic
+
+	@echo "array freelist test"
+	TEST_FREELIST_TYPE=array go test -v -timeout 30m \
+		-coverprofile cover-freelist-array.out -covermode atomic
+
+.PHONY: fmt test test-simulate lint

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -25,7 +25,7 @@ func TestTx_allocatePageStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if tx.Stats().PageCount != prePageCnt+allocateCnt {
+	if tx.Stats().PageCount != prePageCnt+int64(allocateCnt) {
 		t.Errorf("Allocated %d but got %d page in stats", allocateCnt, tx.Stats().PageCount)
 	}
 }

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -18,14 +18,16 @@ func TestTx_allocatePageStats(t *testing.T) {
 		pages: make(map[pgid]*page),
 	}
 
-	prePageCnt := tx.Stats().PageCount
+	txStats := tx.Stats()
+	prePageCnt := txStats.GetPageCount()
 	allocateCnt := f.free_count()
 
 	if _, err := tx.allocate(allocateCnt); err != nil {
 		t.Fatal(err)
 	}
 
-	if tx.Stats().PageCount != prePageCnt+int64(allocateCnt) {
-		t.Errorf("Allocated %d but got %d page in stats", allocateCnt, tx.Stats().PageCount)
+	txStats = tx.Stats()
+	if txStats.GetPageCount() != prePageCnt+int64(allocateCnt) {
+		t.Errorf("Allocated %d but got %d page in stats", allocateCnt, txStats.GetPageCount())
 	}
 }

--- a/bucket.go
+++ b/bucket.go
@@ -3,7 +3,6 @@ package bbolt
 import (
 	"bytes"
 	"fmt"
-	"sync/atomic"
 	"unsafe"
 )
 
@@ -82,7 +81,7 @@ func (b *Bucket) Writable() bool {
 // Do not use a cursor after the transaction is closed.
 func (b *Bucket) Cursor() *Cursor {
 	// Update transaction statistics.
-	atomic.AddInt64(&b.tx.stats.CursorCount, 1)
+	b.tx.stats.IncCursorCount(1)
 
 	// Allocate and return a cursor.
 	return &Cursor{
@@ -682,7 +681,7 @@ func (b *Bucket) node(pgid pgid, parent *node) *node {
 	b.nodes[pgid] = n
 
 	// Update statistics.
-	atomic.AddInt64(&b.tx.stats.NodeCount, 1)
+	b.tx.stats.IncNodeCount(1)
 
 	return n
 }

--- a/bucket.go
+++ b/bucket.go
@@ -3,6 +3,7 @@ package bbolt
 import (
 	"bytes"
 	"fmt"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -81,7 +82,7 @@ func (b *Bucket) Writable() bool {
 // Do not use a cursor after the transaction is closed.
 func (b *Bucket) Cursor() *Cursor {
 	// Update transaction statistics.
-	b.tx.stats.CursorCount++
+	atomic.AddInt64(&b.tx.stats.CursorCount, 1)
 
 	// Allocate and return a cursor.
 	return &Cursor{
@@ -681,7 +682,7 @@ func (b *Bucket) node(pgid pgid, parent *node) *node {
 	b.nodes[pgid] = n
 
 	// Update statistics.
-	b.tx.stats.NodeCount++
+	atomic.AddInt64(&b.tx.stats.NodeCount, 1)
 
 	return n
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1038,8 +1038,8 @@ func TestDB_Stats(t *testing.T) {
 	}
 
 	stats := db.Stats()
-	if stats.TxStats.PageCount != 2 {
-		t.Fatalf("unexpected TxStats.PageCount: %d", stats.TxStats.PageCount)
+	if stats.TxStats.GetPageCount() != 2 {
+		t.Fatalf("unexpected TxStats.PageCount: %d", stats.TxStats.GetPageCount())
 	} else if stats.FreePageN != 0 {
 		t.Fatalf("unexpected FreePageN != 0: %d", stats.FreePageN)
 	} else if stats.PendingPageN != 2 {
@@ -1122,8 +1122,8 @@ func TestDBStats_Sub(t *testing.T) {
 	b.TxStats.PageCount = 10
 	b.FreePageN = 14
 	diff := b.Sub(&a)
-	if diff.TxStats.PageCount != 7 {
-		t.Fatalf("unexpected TxStats.PageCount: %d", diff.TxStats.PageCount)
+	if diff.TxStats.GetPageCount() != 7 {
+		t.Fatalf("unexpected TxStats.PageCount: %d", diff.TxStats.GetPageCount())
 	}
 
 	// free page stats are copied from the receiver and not subtracted

--- a/db_test.go
+++ b/db_test.go
@@ -682,7 +682,9 @@ func TestDB_Concurrent_WriteTo(t *testing.T) {
 			panic(err)
 		}
 		f.Close()
-		snap := btesting.MustOpenDBWithOption(t, f.Name(), o)
+
+		copyOpt := *o
+		snap := btesting.MustOpenDBWithOption(t, f.Name(), &copyOpt)
 		defer snap.MustClose()
 		snap.MustCheck()
 	}

--- a/internal/btesting/btesting.go
+++ b/internal/btesting/btesting.go
@@ -189,14 +189,14 @@ func (db *DB) CopyTempFile() {
 func (db *DB) PrintStats() {
 	var stats = db.Stats()
 	fmt.Printf("[db] %-20s %-20s %-20s\n",
-		fmt.Sprintf("pg(%d/%d)", stats.TxStats.PageCount, stats.TxStats.PageAlloc),
-		fmt.Sprintf("cur(%d)", stats.TxStats.CursorCount),
-		fmt.Sprintf("node(%d/%d)", stats.TxStats.NodeCount, stats.TxStats.NodeDeref),
+		fmt.Sprintf("pg(%d/%d)", stats.TxStats.GetPageCount(), stats.TxStats.GetPageAlloc()),
+		fmt.Sprintf("cur(%d)", stats.TxStats.GetCursorCount()),
+		fmt.Sprintf("node(%d/%d)", stats.TxStats.GetNodeCount(), stats.TxStats.GetNodeDeref()),
 	)
 	fmt.Printf("     %-20s %-20s %-20s\n",
-		fmt.Sprintf("rebal(%d/%v)", stats.TxStats.Rebalance, truncDuration(stats.TxStats.RebalanceTime)),
-		fmt.Sprintf("spill(%d/%v)", stats.TxStats.Spill, truncDuration(stats.TxStats.SpillTime)),
-		fmt.Sprintf("w(%d/%v)", stats.TxStats.Write, truncDuration(stats.TxStats.WriteTime)),
+		fmt.Sprintf("rebal(%d/%v)", stats.TxStats.GetRebalance(), truncDuration(stats.TxStats.GetRebalanceTime())),
+		fmt.Sprintf("spill(%d/%v)", stats.TxStats.GetSpill(), truncDuration(stats.TxStats.GetSpillTime())),
+		fmt.Sprintf("w(%d/%v)", stats.TxStats.GetWrite(), truncDuration(stats.TxStats.GetWriteTime())),
 	)
 }
 

--- a/node.go
+++ b/node.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -304,7 +305,7 @@ func (n *node) splitTwo(pageSize uintptr) (*node, *node) {
 	n.inodes = n.inodes[:splitIndex]
 
 	// Update the statistics.
-	n.bucket.tx.stats.Split++
+	atomic.AddInt64(&n.bucket.tx.stats.Split, 1)
 
 	return n, next
 }
@@ -391,7 +392,7 @@ func (n *node) spill() error {
 		}
 
 		// Update the statistics.
-		tx.stats.Spill++
+		atomic.AddInt64(&tx.stats.Spill, 1)
 	}
 
 	// If the root node split and created a new root then we need to spill that
@@ -547,7 +548,7 @@ func (n *node) dereference() {
 	}
 
 	// Update statistics.
-	n.bucket.tx.stats.NodeDeref++
+	atomic.AddInt64(&n.bucket.tx.stats.NodeDeref, 1)
 }
 
 // free adds the node's underlying page to the freelist.

--- a/node.go
+++ b/node.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"sync/atomic"
 	"unsafe"
 )
 
@@ -305,7 +304,7 @@ func (n *node) splitTwo(pageSize uintptr) (*node, *node) {
 	n.inodes = n.inodes[:splitIndex]
 
 	// Update the statistics.
-	atomic.AddInt64(&n.bucket.tx.stats.Split, 1)
+	n.bucket.tx.stats.IncSplit(1)
 
 	return n, next
 }
@@ -392,7 +391,7 @@ func (n *node) spill() error {
 		}
 
 		// Update the statistics.
-		atomic.AddInt64(&tx.stats.Spill, 1)
+		tx.stats.IncSpill(1)
 	}
 
 	// If the root node split and created a new root then we need to spill that
@@ -414,7 +413,7 @@ func (n *node) rebalance() {
 	n.unbalanced = false
 
 	// Update statistics.
-	n.bucket.tx.stats.Rebalance++
+	n.bucket.tx.stats.IncRebalance(1)
 
 	// Ignore if node is above threshold (25%) and has enough keys.
 	var threshold = n.bucket.tx.db.pageSize / 4
@@ -548,7 +547,7 @@ func (n *node) dereference() {
 	}
 
 	// Update statistics.
-	atomic.AddInt64(&n.bucket.tx.stats.NodeDeref, 1)
+	n.bucket.tx.stats.IncNodeDeref(1)
 }
 
 // free adds the node's underlying page to the freelist.

--- a/tx_stats_test.go
+++ b/tx_stats_test.go
@@ -1,0 +1,54 @@
+package bbolt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxStats_add(t *testing.T) {
+	statsA := TxStats{
+		PageCount:     1,
+		PageAlloc:     2,
+		CursorCount:   3,
+		NodeCount:     100,
+		NodeDeref:     101,
+		Rebalance:     1000,
+		RebalanceTime: 1001 * time.Second,
+		Split:         10000,
+		Spill:         10001,
+		SpillTime:     10001 * time.Second,
+		Write:         100000,
+		WriteTime:     100001 * time.Second,
+	}
+
+	statsB := TxStats{
+		PageCount:     2,
+		PageAlloc:     3,
+		CursorCount:   4,
+		NodeCount:     101,
+		NodeDeref:     102,
+		Rebalance:     1001,
+		RebalanceTime: 1002 * time.Second,
+		Split:         11001,
+		Spill:         11002,
+		SpillTime:     11002 * time.Second,
+		Write:         110001,
+		WriteTime:     110010 * time.Second,
+	}
+
+	statsB.add(&statsA)
+	assert.Equal(t, int64(3), statsB.GetPageCount())
+	assert.Equal(t, int64(5), statsB.GetPageAlloc())
+	assert.Equal(t, int64(7), statsB.GetCursorCount())
+	assert.Equal(t, int64(201), statsB.GetNodeCount())
+	assert.Equal(t, int64(203), statsB.GetNodeDeref())
+	assert.Equal(t, int64(2001), statsB.GetRebalance())
+	assert.Equal(t, 2003*time.Second, statsB.GetRebalanceTime())
+	assert.Equal(t, int64(21001), statsB.GetSplit())
+	assert.Equal(t, int64(21003), statsB.GetSpill())
+	assert.Equal(t, 21003*time.Second, statsB.GetSpillTime())
+	assert.Equal(t, int64(210001), statsB.GetWrite())
+	assert.Equal(t, 210011*time.Second, statsB.GetWriteTime())
+}


### PR DESCRIPTION
Fixes: #213

Signed-off-by: Wei Fu <fuweid89@gmail.com>

------

RFC: Even if updating the type of Stats interface breaks the package usage, I think it should define the size of field with specific type instead of int. So we can use atomic to update the stats instead of introducing the lock.

cc @ahrtr @ptabor