### PR TITLE
security: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
FYI. https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts

Please help to enable dependabot for bbolt, the following example is what I did for raft. @ptabor 

<img width="1229" alt="raft_dependabot" src="https://user-images.githubusercontent.com/30739825/211671988-ed59ede5-207c-41e1-94b9-f503176dc3fc.png">


Signed-off-by: Benjamin Wang <wachao@vmware.com>