### PR TITLE
Revert the signature of `tx.Check` and add `tx.CheckWithStringer`

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -213,7 +213,7 @@ func (cmd *checkCommand) Run(args ...string) error {
 	// Perform consistency check.
 	return db.View(func(tx *bolt.Tx) error {
 		var count int
-		for err := range tx.Check(CmdKvStringer()) {
+		for err := range tx.CheckWithOptions(bolt.WithKVStringer(CmdKvStringer())) {
 			fmt.Fprintln(cmd.Stdout, err)
 			count++
 		}

--- a/db_test.go
+++ b/db_test.go
@@ -398,7 +398,7 @@ func TestOpen_Check(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = db.View(func(tx *bolt.Tx) error { return <-tx.Check(bolt.HexKVStringer()) }); err != nil {
+	if err = db.View(func(tx *bolt.Tx) error { return <-tx.Check() }); err != nil {
 		t.Fatal(err)
 	}
 	if err = db.Close(); err != nil {
@@ -409,7 +409,7 @@ func TestOpen_Check(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.View(func(tx *bolt.Tx) error { return <-tx.Check(bolt.HexKVStringer()) }); err != nil {
+	if err := db.View(func(tx *bolt.Tx) error { return <-tx.Check() }); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {

--- a/internal/btesting/btesting.go
+++ b/internal/btesting/btesting.go
@@ -119,7 +119,7 @@ func (db *DB) MustCheck() {
 	err := db.Update(func(tx *bolt.Tx) error {
 		// Collect all the errors.
 		var errors []error
-		for err := range tx.Check(bolt.HexKVStringer()) {
+		for err := range tx.Check() {
 			errors = append(errors, err)
 			if len(errors) > 10 {
 				break

--- a/internal/tests/tx_check_test.go
+++ b/internal/tests/tx_check_test.go
@@ -39,7 +39,7 @@ func TestTx_RecursivelyCheckPages_MisplacedPage(t *testing.T) {
 	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
 		// Collect all the errors.
 		var errors []error
-		for err := range tx.Check(bolt.HexKVStringer()) {
+		for err := range tx.Check() {
 			errors = append(errors, err)
 		}
 		require.Len(t, errors, 1)
@@ -75,7 +75,7 @@ func TestTx_RecursivelyCheckPages_CorruptedLeaf(t *testing.T) {
 	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
 		// Collect all the errors.
 		var errors []error
-		for err := range tx.Check(bolt.HexKVStringer()) {
+		for err := range tx.Check() {
 			errors = append(errors, err)
 		}
 		require.Len(t, errors, 2)

--- a/tx.go
+++ b/tx.go
@@ -200,7 +200,7 @@ func (tx *Tx) Commit() error {
 
 	// If strict mode is enabled then perform a consistency check.
 	if tx.db.StrictMode {
-		ch := tx.Check(HexKVStringer())
+		ch := tx.Check()
 		var errs []string
 		for {
 			err, ok := <-ch

--- a/tx_test.go
+++ b/tx_test.go
@@ -50,7 +50,7 @@ func TestTx_Check_ReadOnly(t *testing.T) {
 	numChecks := 2
 	errc := make(chan error, numChecks)
 	check := func() {
-		errc <- <-tx.Check(bolt.HexKVStringer())
+		errc <- <-tx.Check()
 	}
 	// Ensure the freelist is not reloaded and does not race.
 	for i := 0; i < numChecks; i++ {


### PR DESCRIPTION
See https://github.com/etcd-io/bbolt/pull/225#discussion_r1089825747

Signed-off-by: Benjamin Wang <wachao@vmware.com>