### PR TITLE
Change error handling logic in db.close()

### DIFF
--- a/tests/failpoint/db_failpoint_test.go
+++ b/tests/failpoint/db_failpoint_test.go
@@ -3,6 +3,7 @@ package failpoint
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -22,4 +23,26 @@ func TestFailpoint_MapFail(t *testing.T) {
 	_, err = bolt.Open(f, 0666, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "map somehow failed")
+}
+
+// ensures when munmap fails, the flock is unlocked
+func TestFailpoint_UnmapFail_DbClose(t *testing.T) {
+	//unmap error on db close
+	//we need to open the db first, and then enable the error.
+	//otherwise the db cannot be opened.
+	f := filepath.Join(t.TempDir(), "db")
+
+	err := gofail.Enable("unmapError", `return("unmap somehow failed")`)
+	require.NoError(t, err)
+	_, err = bolt.Open(f, 0666, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unmap somehow failed")
+	//disable the error, and try to reopen the db
+	err = gofail.Disable("unmapError")
+	require.NoError(t, err)
+
+	db, err := bolt.Open(f, 0666, &bolt.Options{Timeout: 30 * time.Second})
+	require.NoError(t, err)
+	err = db.Close()
+	require.NoError(t, err)
 }


### PR DESCRIPTION
https://github.com/etcd-io/bbolt/issues/382#issuecomment-1414774101
Complete all cleanup operations in db.close() even if there is an error in the middle. Otherwise fd remains open and flock is not released.

Add a test mocking the munmap syscall fails. This test fails before this commit.