### PR TITLE
Add more limitation on searchPage

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -317,11 +317,14 @@ func (c *Cursor) searchPage(key []byte, p *page) {
 	index := sort.Search(int(p.count), func(i int) bool {
 		// TODO(benbjohnson): Optimize this range search. It's a bit hacky right now.
 		// sort.Search() finds the lowest index where f() != -1 but we need the highest index.
-		ret := bytes.Compare(inodes[i].key(), key)
-		if ret == 0 {
-			exact = true
+		if bytes.HasPrefix(inodes[i].key(), key) {
+			ret := bytes.Compare(inodes[i].key(), key)
+			if ret == 0 {
+				exact = true
+			}
+			return ret != -1
 		}
-		return ret != -1
+		return false
 	})
 	if !exact && index > 0 {
 		index--


### PR DESCRIPTION
To avoid goroutine stack exceeds 1000000000-byte limit. 
Some records may result to func `cursor.search()` and `cursor.searchPage` recusively called.

Fixes: #402

Signed-off-by: Miao Xia <xia.miao1@zte.com.cn>