### PR TITLE
Updated go to 1.19.7

### DIFF
--- a/.github/workflows/failpoint_test.yaml
+++ b/.github/workflows/failpoint_test.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.17.13"
+          go-version: "1.19.7"
       - run: |
           make gofail-enable
           make test-failpoint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.17.13"
+        go-version: "1.19.7"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.17.13"
+        go-version: "1.19.7"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/bbolt
 
-go 1.17
+go 1.19
 
 require (
 	github.com/stretchr/testify v1.8.2


### PR DESCRIPTION
This pull request proposes to update to align with go versions used by `etcd` as  Go `1.17` is out of support, this brings `bbolt` in line with other etcd maintained projects and addresses CVEs with older versions of golang.