### PR TITLE
Perform unmap when mlock fails or both meta pages corrupted

### DIFF
--- a/db.go
+++ b/db.go
@@ -388,7 +388,7 @@ func (db *DB) hasSyncedFreelist() bool {
 
 // mmap opens the underlying memory-mapped file and initializes the meta references.
 // minsz is the minimum size that the new mmap can be.
-func (db *DB) mmap(minsz int) error {
+func (db *DB) mmap(minsz int) (err error) {
 	db.mmaplock.Lock()
 	defer db.mmaplock.Unlock()
 
@@ -423,16 +423,26 @@ func (db *DB) mmap(minsz int) error {
 	}
 
 	// Unmap existing data before continuing.
-	if err := db.munmap(); err != nil {
+	if err = db.munmap(); err != nil {
 		return err
 	}
 
 	// Memory-map the data file as a byte slice.
 	// gofail: var mapError string
 	// return errors.New(mapError)
-	if err := mmap(db, size); err != nil {
+	if err = mmap(db, size); err != nil {
 		return err
 	}
+
+	// Perform unmmap on any error to reset all data fields:
+	// dataref, data, datasz, meta0 and meta1.
+	defer func() {
+		if err != nil {
+			if unmapErr := db.munmap(); unmapErr != nil {
+				err = fmt.Errorf("%w; unmap failed: %v", err, unmapErr)
+			}
+		}
+	}()
 
 	if db.Mlock {
 		// Don't allow swapping of data file

--- a/db.go
+++ b/db.go
@@ -517,6 +517,8 @@ func (db *DB) mmapSize(size int) (int, error) {
 }
 
 func (db *DB) munlock(fileSize int) error {
+	// gofail: var munlockError string
+	// return errors.New(munlockError)
 	if err := munlock(db, fileSize); err != nil {
 		return fmt.Errorf("munlock error: " + err.Error())
 	}
@@ -524,6 +526,8 @@ func (db *DB) munlock(fileSize int) error {
 }
 
 func (db *DB) mlock(fileSize int) error {
+	// gofail: var mlockError string
+	// return errors.New(mlockError)
 	if err := mlock(db, fileSize); err != nil {
 		return fmt.Errorf("mlock error: " + err.Error())
 	}

--- a/tests/failpoint/db_failpoint_test.go
+++ b/tests/failpoint/db_failpoint_test.go
@@ -2,7 +2,6 @@ package failpoint
 
 import (
 	"fmt"
-	"go.etcd.io/bbolt/internal/btesting"
 	"path/filepath"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/bbolt/internal/btesting"
 	gofail "go.etcd.io/gofail/runtime"
 )
 


### PR DESCRIPTION
When mlock somehow fails, then bbolt may run into nil pointer error in rollback. The new added test case also fails. The solution is to perform unmap when mlock fails or both meta pages corrupted.

Linked to https://github.com/etcd-io/bbolt/issues/382

```
$ go test -run TestFailpoint_mLockFail_When_remap -timeout 20s
panic: test timed out after 20s

goroutine 50 [running]:
testing.(*M).startAlarm.func1()
	/Users/wachao/software/go/src/testing/testing.go:2036 +0x8e
created by time.goFunc
	/Users/wachao/software/go/src/time/sleep.go:176 +0x32

goroutine 1 [chan receive]:
testing.(*T).Run(0xc0000936c0, {0x131d78b?, 0x1bebc6605467?}, 0x1343410)
	/Users/wachao/software/go/src/testing/testing.go:1494 +0x37a
testing.runTests.func1(0xc0000936c0?)
	/Users/wachao/software/go/src/testing/testing.go:1846 +0x6e
testing.tRunner(0xc0000936c0, 0xc0000f9cd8)
	/Users/wachao/software/go/src/testing/testing.go:1446 +0x10b
testing.runTests(0xc0000d30e0?, {0x154dd40, 0x4, 0x4}, {0x16655b8?, 0x40?, 0x15550e0?})
	/Users/wachao/software/go/src/testing/testing.go:1844 +0x456
testing.(*M).Run(0xc0000d30e0)
	/Users/wachao/software/go/src/testing/testing.go:1726 +0x5d9
main.main()
	_testmain.go:53 +0x1aa

goroutine 21 [semacquire]:
sync.runtime_SemacquireMutex(0xd0?, 0x0?, 0x14d16a0?)
	/Users/wachao/software/go/src/runtime/sema.go:77 +0x25
sync.(*Mutex).lockSlow(0xc000102ab8)
	/Users/wachao/software/go/src/sync/mutex.go:171 +0x165
sync.(*Mutex).Lock(...)
	/Users/wachao/software/go/src/sync/mutex.go:90
go.etcd.io/bbolt.(*DB).beginRWTx(0xc000102900)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:728 +0x77
go.etcd.io/bbolt.(*DB).Begin(0x14d16a0?, 0x20?)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:670 +0x1d
go.etcd.io/bbolt.(*DB).Update(0x151e520?, 0xc0000eb7c0)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:819 +0x3e
go.etcd.io/bbolt/internal/btesting.(*DB).MustCheck(0xc0000b5620)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/internal/btesting/btesting.go:120 +0x45
go.etcd.io/bbolt/internal/btesting.(*DB).PostTestCleanup(0xc0000b5620)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/internal/btesting/btesting.go:70 +0x25
testing.(*common).Cleanup.func1()
	/Users/wachao/software/go/src/testing/testing.go:1041 +0x11f
testing.(*common).runCleanup(0xc000093860, 0xc0000ebf30?)
	/Users/wachao/software/go/src/testing/testing.go:1210 +0x95
testing.tRunner.func2()
	/Users/wachao/software/go/src/testing/testing.go:1440 +0x29
panic({0x12c7620, 0x1546f10})
	/Users/wachao/software/go/src/runtime/panic.go:884 +0x212
go.etcd.io/bbolt/internal/common.(*Meta).Txid(...)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/internal/common/meta.go:118
go.etcd.io/bbolt.(*DB).meta(0xc000118380?)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:1043 +0x30
go.etcd.io/bbolt.(*DB).hasSyncedFreelist(...)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:386
go.etcd.io/bbolt.(*Tx).rollback(0xc00013e000)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/tx.go:283 +0x6e
go.etcd.io/bbolt.(*DB).Update.func1()
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:827 +0x25
panic({0x12c7620, 0x1546f10})
	/Users/wachao/software/go/src/runtime/panic.go:884 +0x212
go.etcd.io/bbolt/internal/common.(*Meta).Txid(...)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/internal/common/meta.go:118
go.etcd.io/bbolt.(*DB).meta(0xc000118380?)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:1043 +0x30
go.etcd.io/bbolt.(*DB).hasSyncedFreelist(...)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:386
go.etcd.io/bbolt.(*Tx).rollback(0xc00013e000)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/tx.go:283 +0x6e
go.etcd.io/bbolt.(*Tx).Commit(0xc00013e000)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/tx.go:163 +0x310
go.etcd.io/bbolt.(*DB).Update(0x16655b8?, 0xc000066e88)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/db.go:842 +0xe5
go.etcd.io/bbolt/internal/btesting.(*DB).Fill(0xc0000b5620, {0xc0000baa18, 0x4, 0x4}, 0x1, 0x2710, 0x1343400, 0x1343408)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/internal/btesting/btesting.go:159 +0x105
go.etcd.io/bbolt/tests/failpoint.TestFailpoint_mLockFail_When_remap(0xc000093860)
	/Users/wachao/go/src/github.com/ahrtr/bbolt/tests/failpoint/db_failpoint_test.go:77 +0x12e
testing.tRunner(0xc000093860, 0x1343410)
	/Users/wachao/software/go/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
	/Users/wachao/software/go/src/testing/testing.go:1493 +0x35f
exit status 2
FAIL	go.etcd.io/bbolt/tests/failpoint	20.688s

```