### PR TITLE
[test] Support enabling strict check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,14 @@ ifdef TIMEOUT
 	TESTFLAGS_TIMEOUT=$(TIMEOUT)
 endif
 
+TESTFLAGS_ENABLE_STRICT_MODE=false
+ifdef ENABLE_STRICT_MODE
+	TESTFLAGS_ENABLE_STRICT_MODE=$(ENABLE_STRICT_MODE)
+endif
+
+.EXPORT_ALL_VARIABLES:
+TEST_ENABLE_STRICT_MODE=${TESTFLAGS_ENABLE_STRICT_MODE}
+
 .PHONY: fmt
 fmt:
 	!(gofmt -l -s -d $(shell find . -name \*.go) | grep '[a-z]')
@@ -53,7 +61,7 @@ gofail-enable: install-gofail
 	gofail enable .
 
 .PHONY: gofail-disable
-gofail-disable:
+gofail-disable: install-gofail
 	gofail disable .
 
 .PHONY: install-gofail

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ ifdef CPU
 endif
 TESTFLAGS = $(TESTFLAGS_RACE) $(TESTFLAGS_CPU) $(EXTRA_TESTFLAGS)
 
+TESTFLAGS_TIMEOUT=30m
+ifdef TIMEOUT
+	TESTFLAGS_TIMEOUT=$(TIMEOUT)
+endif
+
 .PHONY: fmt
 fmt:
 	!(gofmt -l -s -d $(shell find . -name \*.go) | grep '[a-z]')
@@ -24,23 +29,23 @@ lint:
 .PHONY: test
 test:
 	@echo "hashmap freelist test"
-	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout 30m
+	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout ${TESTFLAGS_TIMEOUT}
 	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./internal/...
 	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./cmd/bbolt
 
 	@echo "array freelist test"
-	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout 30m
+	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout ${TESTFLAGS_TIMEOUT}
 	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./internal/...
 	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./cmd/bbolt
 
 .PHONY: coverage
 coverage:
 	@echo "hashmap freelist test"
-	TEST_FREELIST_TYPE=hashmap go test -v -timeout 30m \
+	TEST_FREELIST_TYPE=hashmap go test -v -timeout ${TESTFLAGS_TIMEOUT} \
 		-coverprofile cover-freelist-hashmap.out -covermode atomic
 
 	@echo "array freelist test"
-	TEST_FREELIST_TYPE=array go test -v -timeout 30m \
+	TEST_FREELIST_TYPE=array go test -v -timeout ${TESTFLAGS_TIMEOUT} \
 		-coverprofile cover-freelist-array.out -covermode atomic
 
 .PHONY: gofail-enable

--- a/internal/tests/tx_check_test.go
+++ b/internal/tests/tx_check_test.go
@@ -14,6 +14,7 @@ import (
 
 func TestTx_RecursivelyCheckPages_MisplacedPage(t *testing.T) {
 	db := btesting.MustCreateDB(t)
+	db.ForceDisableStrictMode()
 	require.NoError(t,
 		db.Fill([]byte("data"), 1, 10000,
 			func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
@@ -36,6 +37,7 @@ func TestTx_RecursivelyCheckPages_MisplacedPage(t *testing.T) {
 	require.NoError(t, surgeon.CopyPage(db.Path(), srcPage, targetPage))
 
 	db.MustReopen()
+	db.ForceDisableStrictMode()
 	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
 		// Collect all the errors.
 		var errors []error
@@ -51,6 +53,7 @@ func TestTx_RecursivelyCheckPages_MisplacedPage(t *testing.T) {
 
 func TestTx_RecursivelyCheckPages_CorruptedLeaf(t *testing.T) {
 	db := btesting.MustCreateDB(t)
+	db.ForceDisableStrictMode()
 	require.NoError(t,
 		db.Fill([]byte("data"), 1, 10000,
 			func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
@@ -72,6 +75,7 @@ func TestTx_RecursivelyCheckPages_CorruptedLeaf(t *testing.T) {
 	require.NoError(t, guts_cli.WritePage(db.Path(), pbuf))
 
 	db.MustReopen()
+	db.ForceDisableStrictMode()
 	require.NoError(t, db.Update(func(tx *bolt.Tx) error {
 		// Collect all the errors.
 		var errors []error


### PR DESCRIPTION
Running all test cases in strict mode is extremely costly. Some test workflow also timed out in 4 hours.

We may only enable the strict mode in nightly or weekly test (to be added later in separate PR). 