### PR TITLE
Add a MAINTAINERS to list all members of all roles

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,19 @@
+# The official list of maintainers and reviewers for the project maintenance.
+#
+# Refer to the GOVERNANCE.md in etcd repository for description of the roles.
+#
+# Names should be added to this file like so:
+#     Individual's name <submission email address> (@GITHUB_HANDLE) pkg:*
+#     Individual's name <submission email address> <email2> <emailN> (@GITHUB_HANDLE) pkg:*
+#
+# Please keep the list sorted.
+
+# MAINTAINERS
+Benjamin Wang <wachao@vmware.com> (ahrtr@) #owner/#domain-expert
+Hitoshi Mitake <h.mitake@gmail.com> (@mitake)
+Marek Siarkowicz <marek.siarkowicz@gmail.com> (@serathius)
+Piotr Tabor <ptab@google.com> (@ptabor) #owner/#domain-expert
+Sahdev Zala <spzala@us.ibm.com> (@spzala)
+
+# REVIEWERS
+


### PR DESCRIPTION
As etcd maintainers discussed, we add a separate MAINTAINERS file for each project under etcd-io organization. 

Currently there are only three members in the existing `maintainers-bbolt` github team, so I just added the same list into MAINTAINERS in bbolt. Please anyone feel free to let me know if you have any concerns or comments. 


cc @mitake @ptabor @serathius @spzala @tbg