### PR TITLE
Fix incorrect comment for retrieving a bucket

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -83,7 +83,7 @@ func (b *Bucket) Cursor() *Cursor {
 }
 
 // Bucket retrieves a nested bucket by name.
-// Returns nil if the bucket does not exist.
+// Creates a new bucket if the bucket does not exist.
 // The bucket instance is only valid for the lifetime of the transaction.
 func (b *Bucket) Bucket(name []byte) *Bucket {
 	if b.buckets != nil {

--- a/tx.go
+++ b/tx.go
@@ -96,7 +96,7 @@ func (tx *Tx) Stats() TxStats {
 }
 
 // Bucket retrieves a bucket by name.
-// Returns nil if the bucket does not exist.
+// Creates a new bucket if the bucket does not exist.
 // The bucket instance is only valid for the lifetime of the transaction.
 func (tx *Tx) Bucket(name []byte) *Bucket {
 	return tx.root.Bucket(name)


### PR DESCRIPTION
Fixes #464 

The `Bucket(name []byte)` has the comment that `Returns nil if the bucket does not exist`, which is not correct. Inside the function, it is commented that `Otherwise create a bucket and cache it.` as the last step. So a new bucket would be created if doesn't exist.

Edit: seems incorrect