### PR TITLE
Updated go to latest patch release 1.19.9

### DIFF
--- a/.github/workflows/failpoint_test.yaml
+++ b/.github/workflows/failpoint_test.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.7"
+          go-version: "1.19.9"
       - run: |
           make gofail-enable
           make test-failpoint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.9"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.7"
+        go-version: "1.19.9"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}
@@ -94,6 +94,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.17.13"
+        go-version: "1.19.9"
     - run: make coverage
 


### PR DESCRIPTION
Go 1.19.9 was released 2023-05-02, we should consider updating to stay aligned with main etcd repo go version.

https://go.dev/doc/devel/release#go1.19.minor

> The update includes three security fixes to the html/template package, as well as bug fixes to the compiler, the runtime, and the crypto/tls and syscall packages. See the [Go 1.19.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.9+label%3ACherryPickApproved) on our issue tracker for details. 