### PR TITLE
test: try to reproduce the db corruption issue

### DIFF
--- a/concurrent_test.go
+++ b/concurrent_test.go
@@ -100,30 +100,6 @@ func TestConcurrentReadAndWrite(t *testing.T) {
 		testDuration time.Duration
 	}{
 		{
-			name:         "1 worker",
-			workerCount:  1,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
-			name:         "10 workers",
-			workerCount:  10,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
-			name:         "50 workers",
-			workerCount:  50,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
-			name:         "100 workers",
-			workerCount:  100,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
 			name:         "200 workers",
 			workerCount:  200,
 			conf:         conf,
@@ -214,7 +190,10 @@ func concurrentReadAndWrite(t *testing.T,
 // to ensure the test case can be executed on old branches or versions,
 // e.g. `release-1.3` or `1.3.[5-7]`.
 func mustCreateDB(t *testing.T, o *bolt.Options) *bolt.DB {
-	f := filepath.Join(t.TempDir(), "db")
+	f := "/tmp/bbolt.db"
+	if err := os.Remove(f); err != nil {
+		t.Logf("Failed to remove %q, error: %v", f, err)
+	}
 
 	t.Logf("Opening bbolt DB at: %s", f)
 	if o == nil {


### PR DESCRIPTION
Please do not review this PR. 

FYI. I am trying to reproduce this db corruption issue using the following script + this PR.

```
#!/usr/bin/env bash

# Please run this script at the root directory of the bbolt repository
# using command something like below,
#     ./reproduce_corruption.sh > test.log &

set -euo pipefail

go build ./cmd/bbolt/

minwait=100
maxwait=250
for i in {1..10000}
do
    echo
    echo "-----------------------------------"
    echo "Round $i: $(date)"

    rm -f case.log || true

    TEST_CONCURRENT_CASE_DURATION=300s go test -run TestConcurrentReadAndWrite -v > case.log &
    sleep $((minwait + RANDOM % (maxwait-minwait)))

    pid=$(ps -ef | grep bbolt | grep -v grep | awk '{print $2}')
    echo "Killing ${pid}..."
    kill -9 ${pid}
    sleep 10

    echo "Checking db consistency..."
    ./bbolt page /tmp/bbolt.db 0
    ./bbolt page /tmp/bbolt.db 1
    ./bbolt check /tmp/bbolt.db
    sleep 5
done

echo "All done!"
```