### PR TITLE
Fix deprecated comment.

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -330,7 +330,7 @@ func (tx *Tx) close() {
 // Copy writes the entire database to a writer.
 // This function exists for backwards compatibility.
 //
-// Deprecated; Use WriteTo() instead.
+// Deprecated: Use WriteTo() instead.
 func (tx *Tx) Copy(w io.Writer) error {
 	_, err := tx.WriteTo(w)
 	return err


### PR DESCRIPTION
Correct way of marking a method deprecated is adding a paragraph that
starts with "Deprecated:".

https://go.dev/blog/godoc

https://github.com/golang/go/blob/ff3aefbad4bed0cdd25688329e5cc4f908276a46/src/cmd/api/api.go#L1137
