### PR TITLE
Remove Bucket.ForEachBucket()

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1032,8 +1032,10 @@ func TestBucket_ForEachBucket(t *testing.T) {
 
 	verifyReads := func(b *bolt.Bucket) {
 		var items [][]byte
-		err := b.ForEachBucket(func(k []byte) error {
-			items = append(items, k)
+		err := b.ForEach(func(k, v []byte) error {
+			if v == nil {
+				items = append(items, k)
+			}
 			return nil
 		})
 		assert.NoErrorf(t, err, "b.ForEach failed")
@@ -1071,8 +1073,10 @@ func TestBucket_ForEachBucket_NoBuckets(t *testing.T) {
 
 	verifyReads := func(b *bolt.Bucket) {
 		var items [][]byte
-		err := b.ForEachBucket(func(k []byte) error {
-			items = append(items, k)
+		err := b.ForEach(func(k, v []byte) error {
+			if v == nil {
+				items = append(items, k)
+			}
 			return nil
 		})
 		assert.NoErrorf(t, err, "b.ForEach failed")

--- a/internal/common/page.go
+++ b/internal/common/page.go
@@ -14,6 +14,7 @@ const MinKeysPerPage = 2
 const BranchPageElementSize = unsafe.Sizeof(branchPageElement{})
 const LeafPageElementSize = unsafe.Sizeof(leafPageElement{})
 
+// page flags
 const (
 	BranchPageFlag   = 0x01
 	LeafPageFlag     = 0x02
@@ -21,6 +22,7 @@ const (
 	FreelistPageFlag = 0x10
 )
 
+// inode flags
 const (
 	BucketLeafFlag = 0x01
 )

--- a/tx_check.go
+++ b/tx_check.go
@@ -104,7 +104,10 @@ func (tx *Tx) checkBucket(b *Bucket, reachable map[common.Pgid]*common.Page, fre
 	tx.recursivelyCheckPages(b.RootPage(), kvStringer.KeyToString, ch)
 
 	// Check each bucket within this bucket.
-	_ = b.ForEachBucket(func(k []byte) error {
+	_ = b.ForEach(func(k, v []byte) error {
+		if v != nil {
+			return nil
+		}
 		if child := b.Bucket(k); child != nil {
 			tx.checkBucket(child, reachable, freed, kvStringer, ch)
 		}


### PR DESCRIPTION
@ptabor

https://github.com/etcd-io/bbolt/commit/ebca452da79ad504fe61abb944eddfc140f9301b

With the commit above `Bucket.ForEachBucket` method is introduced. If I am not mistaken, the same functionality can be achieved with existing `Bucket.ForEach` method. When iterating over nested buckets, the value passed to the function is `nil`.

I decided to remove this method as it's been introduced not too long ago and don't really think it's been used anywhere else. If this does not feel the right approach, I can create another PR for marking this method as deprecated.

Thoughts?