### PR TITLE
add github.com/mjl-/bstore to list of projects using bbolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,7 @@ Below is a list of public, open source projects that use Bolt:
 * [BoltDbWeb](https://github.com/evnix/boltdbweb) - A web based GUI for BoltDB files.
 * [BoltDB Viewer](https://github.com/zc310/rich_boltdb) - A BoltDB Viewer Can run on Windows、Linux、Android system.
 * [bleve](http://www.blevesearch.com/) - A pure Go search engine similar to ElasticSearch that uses Bolt as the default storage backend.
+* [bstore](https://github.com/mjl-/bstore) - Database library storing Go values, with referential/unique/nonzero constraints, indices, automatic schema management with struct tags, and a query API.
 * [btcwallet](https://github.com/btcsuite/btcwallet) - A bitcoin wallet.
 * [buckets](https://github.com/joyrexus/buckets) - a bolt wrapper streamlining
   simple tx and key scans.


### PR DESCRIPTION
bstore in turn is used by (and written for) https://github.com/mjl-/mox, a modern mail server. and more recently also in https://github.com/mjl-/vex, a docker registry.

it is similar to some existing data stores providing higher level functionality, but i think bstore has more database-like functionality, like referential integrity checks, (multi-key) indices, and it automatically manages schema changes.
