### PR TITLE
Update import paths to pkg.go.dev and go report card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 bbolt
 =====
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/etcd-io/bbolt?style=flat-square)](https://goreportcard.com/report/github.com/etcd-io/bbolt)
-[![Godoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/etcd-io/bbolt)
+[![Go Report Card](https://goreportcard.com/badge/go.etcd.io/bbolt?style=flat-square)](https://goreportcard.com/report/go.etcd.io/bbolt)
+[![Go Reference](https://pkg.go.dev/badge/go.etcd.io/bbolt.svg)](https://pkg.go.dev/go.etcd.io/bbolt)
 [![Releases](https://img.shields.io/github/release/etcd-io/bbolt/all.svg?style=flat-square)](https://github.com/etcd-io/bbolt/releases)
 [![LICENSE](https://img.shields.io/github/license/etcd-io/bbolt.svg?style=flat-square)](https://github.com/etcd-io/bbolt/blob/master/LICENSE)
 


### PR DESCRIPTION
They pointed to github.com/etcd-io/bbolt, which returns the last bbolt version at the previous module path when used with Go tools, not the actual last version of bbolt. Some time ago, I caught myself using the older github.com import path, and I suspect it was because of these links.

This changes the link from godoc.org to pkg.go.dev, and uses the badge from https://pkg.go.dev/badge/.