### PR TITLE
Improve `CreateBucketIfNotExists` to avoid double searching the same key

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1883,6 +1883,34 @@ func TestBucket_Delete_Quick(t *testing.T) {
 	}
 }
 
+func BenchmarkBucket_CreateBucketIfNotExists(b *testing.B) {
+	db := btesting.MustCreateDB(b)
+	defer db.MustClose()
+
+	const bucketCount = 1_000_000
+
+	err := db.Update(func(tx *bolt.Tx) error {
+		for i := 0; i < bucketCount; i++ {
+			bucketName := fmt.Sprintf("bucket_%d", i)
+			_, berr := tx.CreateBucket([]byte(bucketName))
+			require.NoError(b, berr)
+		}
+		return nil
+	})
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		err := db.Update(func(tx *bolt.Tx) error {
+			_, berr := tx.CreateBucketIfNotExists([]byte("bucket_100"))
+			return berr
+		})
+		require.NoError(b, err)
+	}
+}
+
 func ExampleBucket_Put() {
 	// Open the database.
 	db, err := bolt.Open(tempfile(), 0600, nil)


### PR DESCRIPTION
Fix https://github.com/etcd-io/bbolt/issues/118

Benchmark with this change:
```
BenchmarkBucket_CreateBucketIfNotExists-10    	     123	   9573035 ns/op	   17930 B/op	      37 allocs/op
```

Benchmark with old implementnation:
```
BenchmarkBucket_CreateBucketIfNotExists-10    	     121	  10474415 ns/op	   18147 B/op	      46 allocs/op
```
