### PR TITLE
Updated go to latest patch release 1.19.11

### DIFF
--- a/.github/workflows/failpoint_test.yaml
+++ b/.github/workflows/failpoint_test.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.10"
+          go-version: "1.19.11"
       - run: |
           make gofail-enable
           make test-failpoint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.10"
+        go-version: "1.19.11"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.10"
+        go-version: "1.19.11"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}
@@ -94,6 +94,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.10"
+        go-version: "1.19.11"
     - run: make coverage
 


### PR DESCRIPTION
Maintenance to keep bbolt using latest go patch release for workflows and stay in sync with `etcd-io/etcd`.

Refer: https://github.com/golang/go/issues?q=milestone%3AGo1.19.11+label%3ACherryPickApproved