### PR TITLE
Add binary file /bbolt into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ cover.out
 cover-*.out
 /.idea
 *.iml
+/bbolt
 /cmd/bbolt/bbolt
 


### PR DESCRIPTION
Each time when I build ./bbolt under the root directly, I need to manually remove it afterwards.