### PR TITLE
updated bbolt stats help.

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -829,9 +829,9 @@ The following errors can be reported:
         The page type is not "meta", "leaf", "branch", or "freelist".
 
 No errors should occur in your database. However, if for some reason you
-experience corruption, please submit a ticket to the Bolt project page:
+experience corruption, please submit a ticket to the etcd-io/bbolt project page:
 
-  https://github.com/boltdb/bolt/issues
+  https://github.com/etcd-io/bbolt/issues
 `, "\n")
 }
 


### PR DESCRIPTION
In bbolt CLI  when you run `$bbolt stats -h`, it will give you `https://github.com/boltdb/bolt/issues` to report any issues which is now `archived` then I guess it's better to update it.