### PR TITLE
Open bbolt database with file mode 0600 instead of 0666

### DIFF
--- a/bucket_test.go
+++ b/bucket_test.go
@@ -1885,7 +1885,7 @@ func TestBucket_Delete_Quick(t *testing.T) {
 
 func ExampleBucket_Put() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1928,7 +1928,7 @@ func ExampleBucket_Put() {
 
 func ExampleBucket_Delete() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1986,7 +1986,7 @@ func ExampleBucket_Delete() {
 
 func ExampleBucket_ForEach() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -208,7 +208,7 @@ func (cmd *checkCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0666, &bolt.Options{
+	db, err := bolt.Open(path, 0600, &bolt.Options{
 		ReadOnly:        true,
 		PreLoadFreelist: true,
 	})
@@ -284,7 +284,7 @@ func (cmd *infoCommand) Run(args ...string) error {
 	}
 
 	// Open the database.
-	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -644,7 +644,7 @@ func (cmd *pagesCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0666, &bolt.Options{
+	db, err := bolt.Open(path, 0600, &bolt.Options{
 		ReadOnly:        true,
 		PreLoadFreelist: true,
 	})
@@ -737,7 +737,7 @@ func (cmd *statsCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -868,7 +868,7 @@ func (cmd *bucketsCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -929,7 +929,7 @@ func (cmd *keysCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -1020,7 +1020,7 @@ func (cmd *getCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -1097,7 +1097,7 @@ func (cmd *benchCommand) Run(args ...string) error {
 	}
 
 	// Create database.
-	db, err := bolt.Open(options.Path, 0666, nil)
+	db, err := bolt.Open(options.Path, 0600, nil)
 	if err != nil {
 		return err
 	}
@@ -1652,7 +1652,7 @@ func (cmd *compactCommand) Run(args ...string) (err error) {
 	initialSize := fi.Size()
 
 	// Open source database.
-	src, err := bolt.Open(cmd.SrcPath, 0444, &bolt.Options{ReadOnly: true})
+	src, err := bolt.Open(cmd.SrcPath, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}

--- a/cmd/bbolt/main_test.go
+++ b/cmd/bbolt/main_test.go
@@ -583,7 +583,7 @@ func fillBucket(b *bolt.Bucket, prefix []byte) error {
 }
 
 func chkdb(path string) ([]byte, error) {
-	db, err := bolt.Open(path, 0666, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}

--- a/concurrent_test.go
+++ b/concurrent_test.go
@@ -242,7 +242,7 @@ func mustOpenDB(t *testing.T, dbPath string, o *bolt.Options) *bolt.DB {
 
 	o.FreelistType = freelistType
 
-	db, err := bolt.Open(dbPath, 0666, o)
+	db, err := bolt.Open(dbPath, 0600, o)
 	require.NoError(t, err)
 
 	return db

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -744,7 +744,7 @@ func TestCursor_QuickCheck_BucketsOnly_Reverse(t *testing.T) {
 
 func ExampleCursor() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -798,7 +798,7 @@ func ExampleCursor() {
 
 func ExampleCursor_reverse() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -49,7 +49,7 @@ func TestOpen(t *testing.T) {
 	path := tempfile()
 	defer os.RemoveAll(path)
 
-	db, err := bolt.Open(path, 0666, nil)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if db == nil {
@@ -108,7 +108,7 @@ func TestOpen_MultipleGoroutines(t *testing.T) {
 
 // Ensure that opening a database with a blank path returns an error.
 func TestOpen_ErrPathRequired(t *testing.T) {
-	_, err := bolt.Open("", 0666, nil)
+	_, err := bolt.Open("", 0600, nil)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -116,7 +116,7 @@ func TestOpen_ErrPathRequired(t *testing.T) {
 
 // Ensure that opening a database with a bad path returns an error.
 func TestOpen_ErrNotExists(t *testing.T) {
-	_, err := bolt.Open(filepath.Join(tempfile(), "bad-path"), 0666, nil)
+	_, err := bolt.Open(filepath.Join(tempfile(), "bad-path"), 0600, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -138,7 +138,7 @@ func TestOpen_ErrInvalid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := bolt.Open(path, 0666, nil); err != berrors.ErrInvalid {
+	if _, err := bolt.Open(path, 0600, nil); err != berrors.ErrInvalid {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -174,7 +174,7 @@ func TestOpen_ErrVersionMismatch(t *testing.T) {
 	}
 
 	// Reopen data file.
-	if _, err := bolt.Open(path, 0666, nil); err != berrors.ErrVersionMismatch {
+	if _, err := bolt.Open(path, 0600, nil); err != berrors.ErrVersionMismatch {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -210,7 +210,7 @@ func TestOpen_ErrChecksum(t *testing.T) {
 	}
 
 	// Reopen data file.
-	if _, err := bolt.Open(path, 0666, nil); err != berrors.ErrChecksum {
+	if _, err := bolt.Open(path, 0600, nil); err != berrors.ErrChecksum {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -366,7 +366,7 @@ func TestOpen_Size_Large(t *testing.T) {
 	}
 
 	// Reopen database, update, and check size again.
-	db0, err := bolt.Open(path, 0666, nil)
+	db0, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +396,7 @@ func TestOpen_Check(t *testing.T) {
 	path := tempfile()
 	defer os.RemoveAll(path)
 
-	db, err := bolt.Open(path, 0666, nil)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +407,7 @@ func TestOpen_Check(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	db, err = bolt.Open(path, 0666, nil)
+	db, err = bolt.Open(path, 0600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,7 +429,7 @@ func TestOpen_FileTooSmall(t *testing.T) {
 	path := tempfile()
 	defer os.RemoveAll(path)
 
-	db, err := bolt.Open(path, 0666, nil)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -443,7 +443,7 @@ func TestOpen_FileTooSmall(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = bolt.Open(path, 0666, nil)
+	_, err = bolt.Open(path, 0600, nil)
 	if err == nil || !strings.Contains(err.Error(), "file size too small") {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -460,7 +460,7 @@ func TestDB_Open_InitialMmapSize(t *testing.T) {
 	initMmapSize := 1 << 30  // 1GB
 	testWriteSize := 1 << 27 // 134MB
 
-	db, err := bolt.Open(path, 0666, &bolt.Options{InitialMmapSize: initMmapSize})
+	db, err := bolt.Open(path, 0600, &bolt.Options{InitialMmapSize: initMmapSize})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -533,7 +533,7 @@ func TestDB_Open_ReadOnly(t *testing.T) {
 
 	f := db.Path()
 	o := &bolt.Options{ReadOnly: true}
-	readOnlyDB, err := bolt.Open(f, 0666, o)
+	readOnlyDB, err := bolt.Open(f, 0600, o)
 	if err != nil {
 		panic(err)
 	}
@@ -565,7 +565,7 @@ func TestDB_Open_ReadOnly(t *testing.T) {
 
 func TestDB_Open_ReadOnly_NoCreate(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "db")
-	_, err := bolt.Open(f, 0666, &bolt.Options{ReadOnly: true})
+	_, err := bolt.Open(f, 0600, &bolt.Options{ReadOnly: true})
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
@@ -1348,7 +1348,7 @@ func TestDBUnmap(t *testing.T) {
 
 func ExampleDB_Update() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1388,7 +1388,7 @@ func ExampleDB_Update() {
 
 func ExampleDB_View() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1431,7 +1431,7 @@ func ExampleDB_View() {
 
 func ExampleDB_Begin() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/btesting/btesting.go
+++ b/internal/btesting/btesting.go
@@ -56,7 +56,7 @@ func MustOpenDBWithOption(t testing.TB, f string, o *bolt.Options) *DB {
 
 	o.FreelistType = freelistType
 
-	db, err := bolt.Open(f, 0666, o)
+	db, err := bolt.Open(f, 0600, o)
 	require.NoError(t, err)
 	resDB := &DB{
 		DB: db,
@@ -115,7 +115,7 @@ func (db *DB) MustReopen() {
 		panic("Please call Close() before MustReopen()")
 	}
 	db.t.Logf("Reopening bbolt DB at: %s", db.f)
-	indb, err := bolt.Open(db.Path(), 0666, db.o)
+	indb, err := bolt.Open(db.Path(), 0600, db.o)
 	require.NoError(db.t, err)
 	db.DB = indb
 	db.strictModeEnabledDefault()

--- a/tests/failpoint/db_failpoint_test.go
+++ b/tests/failpoint/db_failpoint_test.go
@@ -22,7 +22,7 @@ func TestFailpoint_MapFail(t *testing.T) {
 	}()
 
 	f := filepath.Join(t.TempDir(), "db")
-	_, err = bolt.Open(f, 0666, nil)
+	_, err = bolt.Open(f, 0600, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "map somehow failed")
 }
@@ -36,14 +36,14 @@ func TestFailpoint_UnmapFail_DbClose(t *testing.T) {
 
 	err := gofail.Enable("unmapError", `return("unmap somehow failed")`)
 	require.NoError(t, err)
-	_, err = bolt.Open(f, 0666, nil)
+	_, err = bolt.Open(f, 0600, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "unmap somehow failed")
 	//disable the error, and try to reopen the db
 	err = gofail.Disable("unmapError")
 	require.NoError(t, err)
 
-	db, err := bolt.Open(f, 0666, &bolt.Options{Timeout: 30 * time.Second})
+	db, err := bolt.Open(f, 0600, &bolt.Options{Timeout: 30 * time.Second})
 	require.NoError(t, err)
 	err = db.Close()
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestFailpoint_mLockFail(t *testing.T) {
 	require.NoError(t, err)
 
 	f := filepath.Join(t.TempDir(), "db")
-	_, err = bolt.Open(f, 0666, &bolt.Options{Mlock: true})
+	_, err = bolt.Open(f, 0600, &bolt.Options{Mlock: true})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "mlock somehow failed")
 
@@ -62,7 +62,7 @@ func TestFailpoint_mLockFail(t *testing.T) {
 	err = gofail.Disable("mlockError")
 	require.NoError(t, err)
 
-	_, err = bolt.Open(f, 0666, &bolt.Options{Mlock: true})
+	_, err = bolt.Open(f, 0600, &bolt.Options{Mlock: true})
 	require.NoError(t, err)
 }
 

--- a/tx_test.go
+++ b/tx_test.go
@@ -37,7 +37,7 @@ func TestTx_Check_ReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	readOnlyDB, err := bolt.Open(db.Path(), 0666, &bolt.Options{ReadOnly: true})
+	readOnlyDB, err := bolt.Open(db.Path(), 0600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -645,7 +645,7 @@ func TestTx_CopyFile_Error_Normal(t *testing.T) {
 func TestTx_Rollback(t *testing.T) {
 	for _, isSyncFreelist := range []bool{false, true} {
 		// Open the database.
-		db, err := bolt.Open(tempfile(), 0666, nil)
+		db, err := bolt.Open(tempfile(), 0600, nil)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -798,7 +798,7 @@ func TestTx_releaseRange(t *testing.T) {
 
 func ExampleTx_Rollback() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -852,7 +852,7 @@ func ExampleTx_Rollback() {
 
 func ExampleTx_CopyFile() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0666, nil)
+	db, err := bolt.Open(tempfile(), 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -882,7 +882,7 @@ func ExampleTx_CopyFile() {
 	defer os.Remove(toFile)
 
 	// Open the cloned database.
-	db2, err := bolt.Open(toFile, 0666, nil)
+	db2, err := bolt.Open(toFile, 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fix: https://github.com/etcd-io/bbolt/issues/544

**Note for reviewers**:
`compact` bbolt command is using file mode `0444` to open the bbolt database. 
https://github.com/etcd-io/bbolt/blob/39d812baeb46547a3adcd122c8e6110e2af0e725/cmd/bbolt/main.go#L1655

I have updated the file mode to `0400` in `compact` sub-command. I hope this fine if not then I can revert it back to `0444`.