### PR TITLE
gitignore: ignore .DS_Store on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ cover-*.out
 *.iml
 /bbolt
 /cmd/bbolt/bbolt
+.DS_Store
 


### PR DESCRIPTION
It would be better to ignore `.DS_Store` generated by macOS.