### PR TITLE
bucket: allow to allocate key on stack in Put()

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -175,15 +175,17 @@ func (b *Bucket) CreateBucket(key []byte) (*Bucket, error) {
 	var value = bucket.write()
 
 	// Insert into node.
-	key = cloneBytes(key)
-	c.node().put(key, key, value, 0, common.BucketLeafFlag)
+	// Tip: Use a new variable `newKey` instead of reusing the existing `key` to prevent
+	// it from being marked as leaking, and accordingly cannot be allocated on stack.
+	newKey := cloneBytes(key)
+	c.node().put(newKey, newKey, value, 0, common.BucketLeafFlag)
 
 	// Since subbuckets are not allowed on inline buckets, we need to
 	// dereference the inline page, if it exists. This will cause the bucket
 	// to be treated as a regular, non-inline bucket for the rest of the tx.
 	b.page = nil
 
-	return b.Bucket(key), nil
+	return b.Bucket(newKey), nil
 }
 
 // CreateBucketIfNotExists creates a new bucket if it doesn't already exist and returns a reference to it.
@@ -230,15 +232,17 @@ func (b *Bucket) CreateBucketIfNotExists(key []byte) (*Bucket, error) {
 	var value = bucket.write()
 
 	// Insert into node.
-	key = cloneBytes(key)
-	c.node().put(key, key, value, 0, common.BucketLeafFlag)
+	// Tip: Use a new variable `newKey` instead of reusing the existing `key` to prevent
+	// it from being marked as leaking, and accordingly cannot be allocated on stack.
+	newKey := cloneBytes(key)
+	c.node().put(newKey, newKey, value, 0, common.BucketLeafFlag)
 
 	// Since subbuckets are not allowed on inline buckets, we need to
 	// dereference the inline page, if it exists. This will cause the bucket
 	// to be treated as a regular, non-inline bucket for the rest of the tx.
 	b.page = nil
 
-	return b.Bucket(key), nil
+	return b.Bucket(newKey), nil
 }
 
 // DeleteBucket deletes a bucket at the given key.
@@ -333,8 +337,10 @@ func (b *Bucket) Put(key []byte, value []byte) error {
 	}
 
 	// Insert into node.
-	key = cloneBytes(key)
-	c.node().put(key, key, value, 0, 0)
+	// Tip: Use a new variable `newKey` instead of reusing the existing `key` to prevent
+	// it from being marked as leaking, and accordingly cannot be allocated on stack.
+	newKey := cloneBytes(key)
+	c.node().put(newKey, newKey, value, 0, 0)
 
 	return nil
 }


### PR DESCRIPTION
While doing some bbolt optimizations for my usecase I have noticed key for `Bucket.Get()` and `Bucket.Delete()` can be allocated on stack, but when I add `Bucket.Put()` it cannot. While in reality it _could_, it seems to be hard for the go compiler. 

```
go version go1.21.0 linux/amd64
```

As per `go build -gcflags -m ./...`:

Old behaviour:
```
./bucket.go:148:31: leaking param: key
./bucket.go:192:42: leaking param: key
./bucket.go:271:22: leaking param: key
```

Now:
```
./bucket.go:148:31: key does not escape
./bucket.go:192:42: key does not escape
./bucket.go:271:22: key does not escape
```

I have performed smoke tests on the benchmark from here https://github.com/etcd-io/bbolt/pull/532/, and got the expected results: 1 less allocation.
```
$ benchstat old new
seed: 42
goos: linux
goarch: amd64
pkg: go.etcd.io/bbolt
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
                                 │     old     │              new              │
                                 │   sec/op    │   sec/op     vs base          │
Bucket_CreateBucketIfNotExists-8   4.820µ ± 1%   4.825µ ± 2%  ~ (p=1.000 n=10)

                                 │     old      │                 new                 │
                                 │     B/op     │     B/op      vs base               │
Bucket_CreateBucketIfNotExists-8   5.418Ki ± 0%   5.402Ki ± 0%  -0.29% (p=0.000 n=10)

                                 │    old     │                new                │
                                 │ allocs/op  │ allocs/op   vs base               │
Bucket_CreateBucketIfNotExists-8   32.00 ± 0%   31.00 ± 0%  -3.12% (p=0.000 n=10)
```
