### PR TITLE
Added bbolt command line version flag to get runtime information.

### DIFF
--- a/cmd/bbolt/README.md
+++ b/cmd/bbolt/README.md
@@ -40,6 +40,7 @@
 
   The commands are:
 
+      version     prints the current version of bbolt
       bench       run synthetic benchmark against bbolt
       buckets     print a list of buckets
       check       verifies integrity of bbolt database
@@ -59,6 +60,21 @@
 - you can use `help` with any command: `bbolt [command] -h` for more information about command.
 
 ## Analyse bbolt database with bbolt command line
+
+### version
+
+- `version` print the current version information of bbolt command-line.
+- usage:
+  `bbolt version`
+
+  Example:
+  
+  ```bash
+  $bbolt version
+  bbolt version: 1.3.7
+  Go Version: go1.20.7
+  Go OS/Arch: darwin/arm64
+  ```
 
 ### info
 

--- a/cmd/bbolt/command_root.go
+++ b/cmd/bbolt/command_root.go
@@ -17,6 +17,7 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(
+		newVersionCobraCommand(),
 		newSurgeryCobraCommand(),
 	)
 

--- a/cmd/bbolt/command_version.go
+++ b/cmd/bbolt/command_version.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+	"go.etcd.io/bbolt/version"
+)
+
+func newVersionCobraCommand() *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "print the current version of bbolt",
+		Long:  "print the current version of bbolt",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("bbolt Version: %s\n", version.Version)
+			fmt.Printf("Go Version: %s\n", runtime.Version())
+			fmt.Printf("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+		},
+	}
+
+	return versionCmd
+}

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -156,6 +156,7 @@ Usage:
 
 The commands are:
 
+    version     print the current version of bbolt
     bench       run synthetic benchmark against bbolt
     buckets     print a list of buckets
     check       verifies integrity of bbolt database

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	// Version shows the last bbolt binary version released.
+	Version = "1.3.7"
+)


### PR DESCRIPTION
Fix https://github.com/etcd-io/bbolt/issues/551

Added `bbolt version` command line flag