### PR TITLE
Update to golang 1.20 minor release

### DIFF
--- a/.github/workflows/failpoint_test.yaml
+++ b/.github/workflows/failpoint_test.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.19.12"
+          go-version: "1.20.7"
       - run: |
           make gofail-enable
           make test-failpoint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.12"
+        go-version: "1.20.7"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}
@@ -66,7 +66,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.12"
+        go-version: "1.20.7"
     - run: make fmt
     - env:
         TARGET: ${{ matrix.target }}
@@ -94,6 +94,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.19.12"
+        go-version: "1.20.7"
     - run: make coverage
 

--- a/cmd/bbolt/main_test.go
+++ b/cmd/bbolt/main_test.go
@@ -461,7 +461,6 @@ func TestCompactCommand_Run(t *testing.T) {
 	if err := binary.Read(crypto.Reader, binary.BigEndian, &s); err != nil {
 		t.Fatal(err)
 	}
-	rand.Seed(s)
 
 	dstdb := btesting.MustCreateDB(t)
 	dstdb.Close()

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -322,7 +322,6 @@ func benchmark_FreelistRelease(b *testing.B, size int) {
 }
 
 func randomPgids(n int) []common.Pgid {
-	rand.Seed(42)
 	pgids := make(common.Pgids, n)
 	for i := range pgids {
 		pgids[i] = common.Pgid(rand.Int63())

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/bbolt
 
-go 1.19
+go 1.20
 
 require (
 	github.com/spf13/cobra v1.7.0

--- a/manydbs_test.go
+++ b/manydbs_test.go
@@ -1,8 +1,8 @@
 package bbolt
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +46,10 @@ func createAndPutKeys(t *testing.T) {
 			}
 
 			var key [16]byte
-			rand.Read(key[:])
+			_, rerr := rand.Read(key[:])
+			if rerr != nil {
+				return rerr
+			}
 			if err := nodes.Put(key[:], nil); err != nil {
 				return err
 			}

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -35,8 +35,6 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 		t.Skip("skipping test in short mode.")
 	}
 
-	rand.Seed(int64(qseed))
-
 	// A list of operations that readers and writers can perform.
 	var readerHandlers = []simulateHandler{simulateGetHandler}
 	var writerHandlers = []simulateHandler{simulateGetHandler, simulatePutHandler}


### PR DESCRIPTION
Migrate `master` to golang `1.20`, as `1.19` is now out of support following the release of go 1.21, refer: https://go.dev/blog/go1.21

Maintenance to keep bbolt in line with main etcd repo.