### PR TITLE
Documentation: remove note that Options.Timeout is Linux/macOS only

### DIFF
--- a/db.go
+++ b/db.go
@@ -1208,8 +1208,7 @@ func (db *DB) freepages() []common.Pgid {
 // Options represents the options that can be set when opening a database.
 type Options struct {
 	// Timeout is the amount of time to wait to obtain a file lock.
-	// When set to zero it will wait indefinitely. This option is only
-	// available on Darwin and Linux.
+	// When set to zero it will wait indefinitely.
 	Timeout time.Duration
 
 	// Sets the DB.NoGrowSync flag before memory mapping the file.


### PR DESCRIPTION
This seems to work on all platforms.
E.g. on Windows it seems to work since 1cb787ee7bfebef44baf98158967a37735e65790.