### PR TITLE
Record the amount of free pages instead of hashmapFreeCount calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,14 @@ lint:
 .PHONY: test
 test:
 	@echo "hashmap freelist test"
-	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout ${TESTFLAGS_TIMEOUT}
-	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./internal/...
-	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./cmd/bbolt
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout ${TESTFLAGS_TIMEOUT}
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./internal/...
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} ./cmd/bbolt
 
 	@echo "array freelist test"
-	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout ${TESTFLAGS_TIMEOUT}
-	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./internal/...
-	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./cmd/bbolt
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout ${TESTFLAGS_TIMEOUT}
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./internal/...
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} ./cmd/bbolt
 
 .PHONY: coverage
 coverage:
@@ -76,8 +76,8 @@ install-gofail:
 .PHONY: test-failpoint
 test-failpoint:
 	@echo "[failpoint] hashmap freelist test"
-	TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout 30m ./tests/failpoint
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=hashmap go test -v ${TESTFLAGS} -timeout 30m ./tests/failpoint
 
 	@echo "[failpoint] array freelist test"
-	TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout 30m ./tests/failpoint
+	BBOLT_VERIFY=all TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout 30m ./tests/failpoint
 

--- a/db.go
+++ b/db.go
@@ -15,9 +15,6 @@ import (
 	"go.etcd.io/bbolt/internal/common"
 )
 
-// When enabled, the database will perform assert function to check the slow-path code
-var assertVerify = os.Getenv("BBOLT_VERIFY") == "true"
-
 // The time elapsed between consecutive file locking attempts.
 const flockRetryTimeout = 50 * time.Millisecond
 
@@ -1311,10 +1308,4 @@ func (s *Stats) Sub(other *Stats) Stats {
 type Info struct {
 	Data     uintptr
 	PageSize int
-}
-
-func _assertVerify(conditionFunc func() bool, msg string, v ...interface{}) {
-	if assertVerify && !conditionFunc() {
-		panic(fmt.Sprintf("assertion failed: "+msg, v...))
-	}
 }

--- a/db.go
+++ b/db.go
@@ -15,6 +15,9 @@ import (
 	"go.etcd.io/bbolt/internal/common"
 )
 
+// When enabled, the database will perform assert function to check the slow-path code
+var assertVerify = os.Getenv("BBOLT_VERIFY") == "true"
+
 // The time elapsed between consecutive file locking attempts.
 const flockRetryTimeout = 50 * time.Millisecond
 
@@ -1308,4 +1311,10 @@ func (s *Stats) Sub(other *Stats) Stats {
 type Info struct {
 	Data     uintptr
 	PageSize int
+}
+
+func _assertVerify(conditionFunc func() bool, msg string, v ...interface{}) {
+	if assertVerify && !conditionFunc() {
+		panic(fmt.Sprintf("assertion failed: "+msg, v...))
+	}
 }

--- a/freelist.go
+++ b/freelist.go
@@ -30,6 +30,7 @@ type freelist struct {
 	freemaps       map[uint64]pidSet                         // key is the size of continuous pages(span), value is a set which contains the starting pgids of same size
 	forwardMap     map[common.Pgid]uint64                    // key is start pgid, value is its span size
 	backwardMap    map[common.Pgid]uint64                    // key is end pgid, value is its span size
+	freePagesCount uint64                                    // count of free pages(hashmap version)
 	allocate       func(txid common.Txid, n int) common.Pgid // the freelist allocate func
 	free_count     func() int                                // the function which gives you free page number
 	mergeSpans     func(ids common.Pgids)                    // the mergeSpan func

--- a/freelist_hmap.go
+++ b/freelist_hmap.go
@@ -8,7 +8,11 @@ import (
 
 // hashmapFreeCount returns count of free pages(hashmap version)
 func (f *freelist) hashmapFreeCount() int {
-	_assertVerify(func() bool { return int(f.freePagesCount) == f.hashmapFreeCountSlow() }, "freePagesCount is out of sync with free pages map")
+	common.Verify(func() {
+		expectedFreePageCount := f.hashmapFreeCountSlow()
+		common.Assert(int(f.freePagesCount) == expectedFreePageCount,
+			"freePagesCount (%d) is out of sync with free pages map (%d)", f.freePagesCount, expectedFreePageCount)
+	})
 	return int(f.freePagesCount)
 }
 

--- a/freelist_test.go
+++ b/freelist_test.go
@@ -448,6 +448,7 @@ func Test_freelist_hashmapGetFreePageIDs(t *testing.T) {
 		val = rand.Int31n(1000)
 		fm[common.Pgid(i)] = uint64(val)
 		i += val
+		f.freePagesCount += uint64(val)
 	}
 
 	f.forwardMap = fm

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -7,13 +7,6 @@ import (
 	"unsafe"
 )
 
-// Assert will panic with a given formatted message if the given condition is false.
-func Assert(condition bool, msg string, v ...interface{}) {
-	if !condition {
-		panic(fmt.Sprintf("assertion failed: "+msg, v...))
-	}
-}
-
 func LoadBucket(buf []byte) *InBucket {
 	return (*InBucket)(unsafe.Pointer(&buf[0]))
 }

--- a/internal/common/verify.go
+++ b/internal/common/verify.go
@@ -1,0 +1,67 @@
+// Copied from https://github.com/etcd-io/etcd/blob/main/client/pkg/verify/verify.go
+package common
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const ENV_VERIFY = "BBOLT_VERIFY"
+
+type VerificationType string
+
+const (
+	ENV_VERIFY_VALUE_ALL    VerificationType = "all"
+	ENV_VERIFY_VALUE_ASSERT VerificationType = "assert"
+)
+
+func getEnvVerify() string {
+	return strings.ToLower(os.Getenv(ENV_VERIFY))
+}
+
+func IsVerificationEnabled(verification VerificationType) bool {
+	env := getEnvVerify()
+	return env == string(ENV_VERIFY_VALUE_ALL) || env == strings.ToLower(string(verification))
+}
+
+// EnableVerifications sets `ENV_VERIFY` and returns a function that
+// can be used to bring the original settings.
+func EnableVerifications(verification VerificationType) func() {
+	previousEnv := getEnvVerify()
+	os.Setenv(ENV_VERIFY, string(verification))
+	return func() {
+		os.Setenv(ENV_VERIFY, previousEnv)
+	}
+}
+
+// EnableAllVerifications enables verification and returns a function
+// that can be used to bring the original settings.
+func EnableAllVerifications() func() {
+	return EnableVerifications(ENV_VERIFY_VALUE_ALL)
+}
+
+// DisableVerifications unsets `ENV_VERIFY` and returns a function that
+// can be used to bring the original settings.
+func DisableVerifications() func() {
+	previousEnv := getEnvVerify()
+	os.Unsetenv(ENV_VERIFY)
+	return func() {
+		os.Setenv(ENV_VERIFY, previousEnv)
+	}
+}
+
+// Verify performs verification if the assertions are enabled.
+// In the default setup running in tests and skipped in the production code.
+func Verify(f func()) {
+	if IsVerificationEnabled(ENV_VERIFY_VALUE_ASSERT) {
+		f()
+	}
+}
+
+// Assert will panic with a given formatted message if the given condition is false.
+func Assert(condition bool, msg string, v ...any) {
+	if !condition {
+		panic(fmt.Sprintf("assertion failed: "+msg, v...))
+	}
+}


### PR DESCRIPTION
This is an attempt to continue the work started in https://github.com/etcd-io/bbolt/pull/282.