### PR TITLE
Enable arm64 runner

### DIFF
--- a/.github/workflows/tests_arm64.yaml
+++ b/.github/workflows/tests_arm64.yaml
@@ -1,0 +1,48 @@
+name: Tests ARM64
+on: [push, pull_request]
+jobs:
+  test-linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - linux-arm64-unit-test-1-cpu
+        - linux-arm64-unit-test-2-cpu
+        - linux-arm64-unit-test-4-cpu
+        - linux-arm64-unit-test-4-cpu-race
+    runs-on: actuated-arm64-8cpu-32gb
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with:
+        go-version: "1.21.1"
+    - run: make fmt
+    - env:
+        TARGET: ${{ matrix.target }}
+      run: |
+        case "${TARGET}" in
+          linux-arm64-unit-test-1-cpu)
+            CPU=1 make test
+            ;;
+          linux-arm64-unit-test-2-cpu)
+            CPU=2 make test
+            ;;
+          linux-arm64-unit-test-4-cpu)
+            CPU=4 make test
+            ;;
+          linux-arm64-unit-test-4-cpu-race)
+            # XXX: By default, the Github Action runner will terminate the process
+            # if it has high resource usage. Try to use GOGC to limit memory and
+            # cpu usage here to prevent unexpected terminating. It can be replaced
+            # with GOMEMLIMIT=2048MiB if the go-version is updated to >=1.19.x.
+            #
+            # REF: https://github.com/actions/runner-images/issues/6680#issuecomment-1335778010
+            GOGC=30 CPU=4 ENABLE_RACE=true make test
+            ;;
+          *)
+            echo "Failed to find target"
+            exit 1
+            ;;
+        esac
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0


### PR DESCRIPTION
Enable tests to run on the ARM64 runner. Fixes #583.

