### PR TITLE
github wokflow: use large runner, remove limits

### DIFF
--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -6,7 +6,11 @@ on:
       runs-on:
         required: false
         type: string
-        default: "['ubuntu-latest']"
+        default: ubuntu-latest
+      targets:
+        required: false
+        type: string
+        default: "['linux-unit-test-1-cpu','linux-unit-test-2-cpu','linux-unit-test-4-cpu']"
 permissions: read-all
 
 jobs:
@@ -14,12 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - linux-unit-test-1-cpu
-          - linux-unit-test-2-cpu
-          - linux-unit-test-4-cpu
-          - linux-unit-test-4-cpu-race
-    runs-on: ${{ fromJson(inputs.runs-on) }}
+        target: ${{ fromJSON(inputs.targets) }}
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - id: goversion
@@ -42,13 +42,7 @@ jobs:
               CPU=4 make test
               ;;
             linux-unit-test-4-cpu-race)
-              # XXX: By default, the Github Action runner will terminate the process
-              # if it has high resource usage. Try to use GOGC to limit memory and
-              # cpu usage here to prevent unexpected terminating. It can be replaced
-              # with GOMEMLIMIT=2048MiB if the go-version is updated to >=1.19.x.
-              #
-              # REF: https://github.com/actions/runner-images/issues/6680#issuecomment-1335778010
-              GOGC=30 CPU=4 ENABLE_RACE=true make test
+              CPU=4 ENABLE_RACE=true make test
               ;;
             *)
               echo "Failed to find target"

--- a/.github/workflows/tests_amd64.yaml
+++ b/.github/workflows/tests_amd64.yaml
@@ -4,10 +4,17 @@ on: [push, pull_request]
 jobs:
   test-linux-amd64:
     uses: ./.github/workflows/tests-template.yml
+  test-linux-amd64-race:
+    uses: ./.github/workflows/tests-template.yml
+    with:
+      runs-on: ubuntu-latest-8-cores
+      targets: "['linux-unit-test-4-cpu-race']"
 
   coverage:
-    needs: ["test-linux-amd64"]
-    runs-on: ubuntu-latest
+    needs:
+      - test-linux-amd64
+      - test-linux-amd64-race
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v4
       - id: goversion

--- a/.github/workflows/tests_arm64.yaml
+++ b/.github/workflows/tests_arm64.yaml
@@ -5,4 +5,9 @@ jobs:
   test-linux-arm64:
     uses: ./.github/workflows/tests-template.yml
     with:
-      runs-on: "['actuated-arm64-4cpu-16gb']"
+      runs-on: actuated-arm64-4cpu-16gb
+  test-linux-arm64-race:
+    uses: ./.github/workflows/tests-template.yml
+    with:
+      runs-on: actuated-arm64-8cpu-16gb
+      targets: "['linux-unit-test-4-cpu-race']"


### PR DESCRIPTION
Remove the resource limits from `GOGC`, and set the GitHub workflow to run on a large Ubuntu runner.

Fixes #609