### PR TITLE
Add log when `file.WriteAt` or `syscall.Fdatasync` fails

### DIFF
--- a/bolt_linux.go
+++ b/bolt_linux.go
@@ -7,9 +7,10 @@ import (
 
 // fdatasync flushes written data to a file descriptor.
 func fdatasync(db *DB) error {
+	fmt.Printf("linux: fdatasync started\n")
 	err := syscall.Fdatasync(int(db.file.Fd()))
 	if err != nil {
-		fmt.Printf("linux: fdatasync failed: %v", err)
+		fmt.Printf("linux: fdatasync failed: %v\n", err)
 	}
 	return err
 }

--- a/bolt_linux.go
+++ b/bolt_linux.go
@@ -1,10 +1,15 @@
 package bbolt
 
 import (
+	"fmt"
 	"syscall"
 )
 
 // fdatasync flushes written data to a file descriptor.
 func fdatasync(db *DB) error {
-	return syscall.Fdatasync(int(db.file.Fd()))
+	err := syscall.Fdatasync(int(db.file.Fd()))
+	if err != nil {
+		fmt.Printf("linux: fdatasync failed: %v", err)
+	}
+	return err
 }

--- a/bolt_linux.go
+++ b/bolt_linux.go
@@ -7,7 +7,6 @@ import (
 
 // fdatasync flushes written data to a file descriptor.
 func fdatasync(db *DB) error {
-	fmt.Printf("linux: fdatasync started\n")
 	err := syscall.Fdatasync(int(db.file.Fd()))
 	if err != nil {
 		fmt.Printf("linux: fdatasync failed: %v\n", err)

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1237,7 +1237,7 @@ func (cmd *benchCommand) runWritesWithSource(db *bolt.DB, options *BenchOptions,
 			b, _ := tx.CreateBucketIfNotExists(benchBucketName)
 			b.FillPercent = options.FillPercent
 
-			fmt.Fprintf(cmd.Stderr, "Starting write iteration %d\n", i)
+			//fmt.Fprintf(cmd.Stderr, "Starting write iteration %d\n", i)
 			for j := int64(0); j < options.BatchSize; j++ {
 				key := make([]byte, options.KeySize)
 				value := make([]byte, options.ValueSize)
@@ -1252,7 +1252,7 @@ func (cmd *benchCommand) runWritesWithSource(db *bolt.DB, options *BenchOptions,
 
 				results.AddCompletedOps(1)
 			}
-			fmt.Fprintf(cmd.Stderr, "Finished write iteration %d\n", i)
+			//fmt.Fprintf(cmd.Stderr, "Finished write iteration %d\n", i)
 
 			return nil
 		}); err != nil {

--- a/tx.go
+++ b/tx.go
@@ -455,6 +455,7 @@ func (tx *Tx) write() error {
 			buf := common.UnsafeByteSlice(unsafe.Pointer(p), written, 0, int(sz))
 
 			if _, err := tx.db.ops.writeAt(buf, offset); err != nil {
+				fmt.Printf("writeAt (offset: %d) failed: %v\n", offset, err)
 				return err
 			}
 
@@ -509,6 +510,7 @@ func (tx *Tx) writeMeta() error {
 
 	// Write the meta page to file.
 	if _, err := tx.db.ops.writeAt(buf, int64(p.Id())*int64(tx.db.pageSize)); err != nil {
+		fmt.Printf("writeMeta: writeAt (p.Id(): %d) failed: %v\n", p.Id(), err)
 		return err
 	}
 	if !tx.db.NoSync || common.IgnoreNoSync {


### PR DESCRIPTION
Note: this PR isn't for merge. It's just used to verify the test case in https://github.com/etcd-io/bbolt/issues/568