### PR TITLE
github workflow: only run arm64 for etcd-io/bbolt

### DIFF
--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -15,6 +15,8 @@ permissions: read-all
 
 jobs:
   test-linux:
+    # this is to prevent arm64 jobs from running at forked projects
+    if: ${{ github.repository == 'etcd-io/bbolt' || startsWith(inputs.runs-on, 'ubuntu') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Skip running arm64 jobs that use actuated's runners for commits done in forked repositories. These jobs will not run and eventually fail in GitHub actions.

Fixes #619 