### PR TITLE
CHANGELOG: update for v1.3.9

### DIFF
--- a/CHANGELOG/CHANGELOG-1.3.md
+++ b/CHANGELOG/CHANGELOG-1.3.md
@@ -1,5 +1,10 @@
 Note that we start to track changes starting from v1.3.7.
 
+## v1.3.9(TBD)
+
+### BoltDB
+- [Clone the key before operating data in bucket against the key](https://github.com/etcd-io/bbolt/pull/639)
+
 <hr>
 
 ## v1.3.8(2023-10-26)


### PR DESCRIPTION
- [bucket: allow to allocate key on stack in Put()](https://github.com/etcd-io/bbolt/pull/550)
- [bucket.Put: copy key before seek](https://github.com/etcd-io/bbolt/pull/637)
- [copy key before comparing during CreateBucket or CreateBucketIfNotExists](https://github.com/etcd-io/bbolt/pull/641)