### PR TITLE
Tune arm64 memory allocation and disable telemetry

### DIFF
--- a/.github/workflows/failpoint_test.yaml
+++ b/.github/workflows/failpoint_test.yaml
@@ -1,3 +1,4 @@
+---
 name: Failpoint test
 on: [push, pull_request]
 permissions: read-all

--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -23,8 +23,6 @@ jobs:
         target: ${{ fromJSON(inputs.targets) }}
     runs-on: ${{ inputs.runs-on }}
     steps:
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v1
       - uses: actions/checkout@v4
       - id: goversion
         run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests_amd64.yaml
+++ b/.github/workflows/tests_amd64.yaml
@@ -1,3 +1,4 @@
+---
 name: Tests AMD64
 permissions: read-all
 on: [push, pull_request]

--- a/.github/workflows/tests_arm64.yaml
+++ b/.github/workflows/tests_arm64.yaml
@@ -1,3 +1,4 @@
+---
 name: Tests ARM64
 permissions: read-all
 on: [push, pull_request]

--- a/.github/workflows/tests_arm64.yaml
+++ b/.github/workflows/tests_arm64.yaml
@@ -5,9 +5,9 @@ jobs:
   test-linux-arm64:
     uses: ./.github/workflows/tests-template.yml
     with:
-      runs-on: actuated-arm64-4cpu-16gb
+      runs-on: actuated-arm64-4cpu-8gb
   test-linux-arm64-race:
     uses: ./.github/workflows/tests-template.yml
     with:
-      runs-on: actuated-arm64-8cpu-16gb
+      runs-on: actuated-arm64-8cpu-8gb
       targets: "['linux-unit-test-4-cpu-race']"

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -1,3 +1,4 @@
+---
 name: Tests
 on: [push, pull_request]
 jobs:
@@ -14,7 +15,7 @@ jobs:
         #
         #   ThreadSanitizer failed to allocate 0x000200000000 (8589934592) bytes at 0x0400c0000000 (error code: 1455)
         #
-        #- windows-amd64-unit-test-4-cpu-race
+        # - windows-amd64-unit-test-4-cpu-race
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +42,7 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
 
   coverage:
-    needs: ["test-windows" ]
+    needs: ["test-windows"]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request tunes `arm64` actuated.dev runner memory requests down from `16gb` to `8gb` to better reflect what our workflows actually need based on telemetry and ensure we are being good citizens with this shared infrastructure.

In https://github.com/etcd-io/bbolt/pull/640 we introduced the telemetry and based on [recent workflow runs](https://github.com/etcd-io/bbolt/actions/runs/7339036148) it looks like we stay under `4gb` currently:  

![image](https://github.com/etcd-io/bbolt/assets/39425256/0d3fc8cf-47d5-4abb-9d66-d6199992d988)

With this tuning now complete I have also removed the workflow telemetry to reduce noise.

Fixes: https://github.com/etcd-io/etcd/issues/17045


Note: I also tidied up a couple of things `yamllint` complained about in the workflow files.