### PR TITLE
test: introduce nightly job for robustness test

### DIFF
--- a/.github/workflows/robustness_nightly.yaml
+++ b/.github/workflows/robustness_nightly.yaml
@@ -1,0 +1,17 @@
+---
+name: Robustness Nightly
+permissions: read-all
+on:
+  schedule:
+    - cron: '25 9 * * *' # runs every day at 09:25 UTC
+  # workflow_dispatch enables manual testing of this job by maintainers
+  workflow_dispatch:
+
+jobs:
+  main:
+    # GHA has a maximum amount of 6h execution time, we try to get done within 3h
+    uses: ./.github/workflows/robustness_template.yaml
+    with:
+      count: 100
+      testTimeout: 200m
+      runs-on: "['ubuntu-latest-8-cores']"

--- a/.github/workflows/robustness_template.yaml
+++ b/.github/workflows/robustness_template.yaml
@@ -1,0 +1,38 @@
+---
+name: Reusable Robustness Workflow
+on:
+  workflow_call:
+    inputs:
+      count:
+        required: true
+        type: number
+      testTimeout:
+        required: false
+        type: string
+        default: '30m'
+      runs-on:
+        required: false
+        type: string
+        default: "['ubuntu-latest']"
+permissions: read-all
+
+jobs:
+  test:
+    timeout-minutes: 210
+    runs-on: ${{ fromJson(inputs.runs-on) }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: goversion
+        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - name: test-robustness
+        run: |
+          set -euo pipefail
+
+          make gofail-enable
+
+          # build bbolt with failpoint
+          go install ./cmd/bbolt
+          sudo -E PATH=$PATH make ROBUSTNESS_TESTFLAGS="--count ${{ inputs.count }} --timeout ${{ inputs.testTimeout }} -failfast" test-robustness

--- a/.github/workflows/robustness_test.yaml
+++ b/.github/workflows/robustness_test.yaml
@@ -3,16 +3,8 @@ on: [push, pull_request]
 permissions: read-all
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
-      - run: |
-          make gofail-enable
-          # build bbolt with failpoint
-          go install ./cmd/bbolt
-          sudo -E PATH=$PATH make test-robustness
+    uses: ./.github/workflows/robustness_template.yaml
+    with:
+      count: 10
+      testTimeout: 30m
+      runs-on: "['ubuntu-latest-8-cores']"

--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,4 @@ test-failpoint:
 .PHONY: test-robustness # Running robustness tests requires root permission
 test-robustness:
 	go test -v ${TESTFLAGS} ./tests/dmflakey -test.root
-	go test -v ${TESTFLAGS} ./tests/robustness -test.root
+	go test -v ${TESTFLAGS} ${ROBUSTNESS_TESTFLAGS} ./tests/robustness -test.root

--- a/tests/dmflakey/dmflakey.go
+++ b/tests/dmflakey/dmflakey.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -287,6 +288,10 @@ func createEmptyFSImage(imgPath string, fsType FSType) error {
 
 	if _, err := os.Stat(imgPath); err == nil {
 		return fmt.Errorf("failed to create image because %s already exists", imgPath)
+	}
+
+	if err := os.MkdirAll(path.Dir(imgPath), 0600); err != nil {
+		return fmt.Errorf("failed to ensure parent directory %s: %w", path.Dir(imgPath), err)
 	}
 
 	f, err := os.Create(imgPath)


### PR DESCRIPTION
* tests: Update TestRestartFromPowerFailure

Update case with a combination of EXT4 filesystem's commit setting and unexpected exit event. That EXT4 filesystem's commit is to sync all its data and metadata every seconds. The kernel can help us sync even if that process has been killed. With different commit setting, we can simulate that case that kernel syncs half part of dirty pages before power
failure. And for unexpected exit event, we can kill that process randomly or panic at failpoint instead of fixed code path.

* *: introduce nightly run for robustness test

Update GITHUB CI workflow for nightly run. Nightly run job takes 1h and is be verified in my fork https://github.com/fuweid/bbolt/actions/runs/7378167227/job/20072981571