### PR TITLE
tests/robustness: switch to kill if no panic after 10sec

### DIFF
--- a/tests/robustness/powerfailure_test.go
+++ b/tests/robustness/powerfailure_test.go
@@ -94,6 +94,7 @@ func doPowerFailure(t *testing.T, du time.Duration, fsMountOpt string, useFailpo
 		"-path", dbPath,
 		"-count=1000000000",
 		"-batch-size=5", // separate total count into multiple truncation
+		"-value-size=512",
 	}
 
 	logPath := filepath.Join(t.TempDir(), fmt.Sprintf("%s.log", t.Name()))
@@ -140,7 +141,7 @@ func doPowerFailure(t *testing.T, du time.Duration, fsMountOpt string, useFailpo
 
 	select {
 	case <-time.After(10 * time.Second):
-		t.Error("bbolt should stop with panic in seconds")
+		t.Log("bbolt is supposed to be already stopped, but actually not yet; forcibly kill it")
 		assert.NoError(t, cmd.Process.Kill())
 	case err := <-errCh:
 		require.Error(t, err)


### PR DESCRIPTION
If file doesn't grow in 10 sec, bbolt won't trigger the following errors:

* lackOfDiskSpace
* mapError
* resizeFileError
* unmapError

We should switch to kill instead of waiting for panic. In order to trigger these errors, we should increase value size to 512.