### PR TITLE
*: run test-robustness with build

### DIFF
--- a/.github/workflows/robustness_template.yaml
+++ b/.github/workflows/robustness_template.yaml
@@ -31,8 +31,4 @@ jobs:
         run: |
           set -euo pipefail
 
-          make gofail-enable
-
-          # build bbolt with failpoint
-          go install ./cmd/bbolt
-          sudo -E PATH=$PATH make ROBUSTNESS_TESTFLAGS="--count ${{ inputs.count }} --timeout ${{ inputs.testTimeout }} -failfast" test-robustness
+          ROBUSTNESS_TESTFLAGS="--count ${{ inputs.count }} --timeout ${{ inputs.testTimeout }} -failfast" make test-robustness

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,15 @@ coverage:
 	TEST_FREELIST_TYPE=array go test -v -timeout ${TESTFLAGS_TIMEOUT} \
 		-coverprofile cover-freelist-array.out -covermode atomic
 
+BOLT_CMD=bbolt
+
+build:
+	go build -o bin/${BOLT_CMD} ./cmd/${BOLT_CMD}
+
+.PHONY: clean
+clean: # Clean binaries
+	rm -f ./bin/${BOLT_CMD}
+
 .PHONY: gofail-enable
 gofail-enable: install-gofail
 	gofail enable .
@@ -82,6 +91,6 @@ test-failpoint:
 	BBOLT_VERIFY=all TEST_FREELIST_TYPE=array go test -v ${TESTFLAGS} -timeout 30m ./tests/failpoint
 
 .PHONY: test-robustness # Running robustness tests requires root permission
-test-robustness:
-	go test -v ${TESTFLAGS} ./tests/dmflakey -test.root
-	go test -v ${TESTFLAGS} ${ROBUSTNESS_TESTFLAGS} ./tests/robustness -test.root
+test-robustness: gofail-enable build
+	sudo env PATH=$$PATH go test -v ${TESTFLAGS} ./tests/dmflakey -test.root
+	sudo env PATH=$(PWD)/bin:$$PATH go test -v ${TESTFLAGS} ${ROBUSTNESS_TESTFLAGS} ./tests/robustness -test.root


### PR DESCRIPTION
Follow-up: https://github.com/etcd-io/bbolt/pull/658#discussion_r1439223250


Add new recipe to build bbolt command so that we can ensure that test-robustness recipe is using bbolt with gofail.

Since test-robustness requires root, move `sudo` into test-robustness recipe. Otherwise, both bbolt binary and gofail code belongs to root user.

Signed-off-by: Wei Fu <fuweid89@gmail.com>