### PR TITLE
Prevent `MoveBucket` from moving a bucket across two different db files

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -343,8 +343,13 @@ func (b *Bucket) MoveBucket(key []byte, dstBucket *Bucket) (err error) {
 
 	if b.tx.db == nil || dstBucket.tx.db == nil {
 		return errors.ErrTxClosed
-	} else if !dstBucket.Writable() {
+	} else if !b.Writable() || !dstBucket.Writable() {
 		return errors.ErrTxNotWritable
+	}
+
+	if b.tx.db.Path() != dstBucket.tx.db.Path() || b.tx != dstBucket.tx {
+		lg.Errorf("The source and target buckets are not in the same db file, source bucket in %s and target bucket in %s", b.tx.db.Path(), dstBucket.tx.db.Path())
+		return errors.ErrDifferentDB
 	}
 
 	newKey := cloneBytes(key)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -77,4 +77,8 @@ var (
 	// ErrSameBuckets is returned when trying to move a sub-bucket between
 	// source and target buckets, while source and target buckets are the same.
 	ErrSameBuckets = errors.New("the source and target are the same bucket")
+
+	// ErrDifferentDB is returned when trying to move a sub-bucket between
+	// source and target buckets, while source and target buckets are in different database files.
+	ErrDifferentDB = errors.New("the source and target buckets are in different database files")
 )


### PR DESCRIPTION
This PR adds more test to move bucket feature

- Test moving buckets between two different database files
- Test moving buckets using two different transactions 

Refer to https://github.com/etcd-io/bbolt/pull/635#discussion_r1440256817

cc @ahrtr @fuweid 