### PR TITLE
Fix `bbolt keys` and `bbolt get` to prevent them from panicking when no parameter provided

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -55,6 +55,9 @@ var (
 
 	// ErrKeyNotFound is returned when a key is not found.
 	ErrKeyNotFound = errors.New("key not found")
+
+	// ErrNotEnoughArgs is returned with a cmd is being executed with fewer arguments.
+	ErrNotEnoughArgs = errors.New("not enough arguments")
 )
 
 func main() {
@@ -921,6 +924,9 @@ func (cmd *keysCommand) Run(args ...string) error {
 
 	// Require database path and bucket.
 	relevantArgs := fs.Args()
+	if len(relevantArgs) < 2 {
+		return ErrNotEnoughArgs
+	}
 	path, buckets := relevantArgs[0], relevantArgs[1:]
 	if path == "" {
 		return ErrPathRequired
@@ -1000,6 +1006,9 @@ func (cmd *getCommand) Run(args ...string) error {
 
 	// Require database path, bucket and key.
 	relevantArgs := fs.Args()
+	if len(relevantArgs) < 3 {
+		return ErrNotEnoughArgs
+	}
 	path, buckets := relevantArgs[0], relevantArgs[1:len(relevantArgs)-1]
 	key, err := parseBytes(relevantArgs[len(relevantArgs)-1], parseFormat)
 	if err != nil {

--- a/cmd/bbolt/main_test.go
+++ b/cmd/bbolt/main_test.go
@@ -649,6 +649,33 @@ func TestCompactCommand_Run(t *testing.T) {
 	}
 }
 
+func TestCommands_Run_NoArgs(t *testing.T) {
+	testCases := []struct {
+		name   string
+		cmd    string
+		expErr error
+	}{
+		{
+			name:   "get",
+			cmd:    "get",
+			expErr: main.ErrNotEnoughArgs,
+		},
+		{
+			name:   "keys",
+			cmd:    "keys",
+			expErr: main.ErrNotEnoughArgs,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMain()
+			err := m.Run(tc.cmd)
+			require.ErrorIs(t, err, main.ErrNotEnoughArgs)
+		})
+	}
+}
+
 func fillBucket(b *bolt.Bucket, prefix []byte) error {
 	n := 10 + rand.Intn(50)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
resolves https://github.com/etcd-io/bbolt/issues/681

cc @ahrtr 