### PR TITLE
Adding txid to meta surgery

### DIFF
--- a/cmd/bbolt/command_surgery_meta.go
+++ b/cmd/bbolt/command_surgery_meta.go
@@ -19,6 +19,7 @@ const (
 	metaFieldRoot     = "root"
 	metaFieldFreelist = "freelist"
 	metaFieldPgid     = "pgid"
+	metaFieldTxid     = "txid"
 )
 
 func newSurgeryMetaCommand() *cobra.Command {
@@ -88,6 +89,7 @@ var allowedMetaUpdateFields = map[string]struct{}{
 	metaFieldRoot:     {},
 	metaFieldFreelist: {},
 	metaFieldPgid:     {},
+	metaFieldTxid:     {},
 }
 
 // AddFlags sets the flags for `meta update` command.
@@ -220,6 +222,8 @@ func updateMetaField(m *common.Meta, fields map[string]uint64) bool {
 			m.SetFreelist(common.Pgid(val))
 		case metaFieldPgid:
 			m.SetPgid(common.Pgid(val))
+		case metaFieldTxid:
+			m.SetTxid(common.Txid(val))
 		}
 
 		changed = true

--- a/cmd/bbolt/command_surgery_meta_test.go
+++ b/cmd/bbolt/command_surgery_meta_test.go
@@ -40,6 +40,7 @@ func TestSurgery_Meta_Update(t *testing.T) {
 		root     common.Pgid
 		freelist common.Pgid
 		pgid     common.Pgid
+		txid     common.Txid
 	}{
 		{
 			name: "root changed",
@@ -52,6 +53,10 @@ func TestSurgery_Meta_Update(t *testing.T) {
 		{
 			name: "pgid changed",
 			pgid: 600,
+		},
+		{
+			name: "txid changed",
+			txid: 42,
 		},
 		{
 			name:     "both root and freelist changed",
@@ -68,6 +73,7 @@ func TestSurgery_Meta_Update(t *testing.T) {
 			root:     43,
 			freelist: 62,
 			pgid:     256,
+			txid:     22,
 		},
 	}
 
@@ -92,6 +98,9 @@ func TestSurgery_Meta_Update(t *testing.T) {
 				}
 				if tc.pgid != 0 {
 					fields = append(fields, fmt.Sprintf("pgid:%d", tc.pgid))
+				}
+				if tc.txid != 0 {
+					fields = append(fields, fmt.Sprintf("txid:%d", tc.txid))
 				}
 
 				rootCmd := main.NewRootCommand()
@@ -119,6 +128,9 @@ func TestSurgery_Meta_Update(t *testing.T) {
 				}
 				if tc.pgid != 0 {
 					require.Equal(t, tc.pgid, m.Pgid())
+				}
+				if tc.txid != 0 {
+					require.Equal(t, tc.txid, m.Txid())
 				}
 			})
 		}


### PR DESCRIPTION
It seems advertised in the help, but it wasn't implemented yet. 

Not as safe as reverting the meta page entirely, seems like a more hackish way of changing their ordering that I tried. So feel free to reject/close it again :)
