### PR TITLE
bench: aggregate adding completed ops for reads

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1380,13 +1380,22 @@ func (cmd *benchCommand) runReadsSequential(db *bolt.DB, options *BenchOptions, 
 
 		for {
 			numReads := int64(0)
-			c := tx.Bucket(benchBucketName).Cursor()
-			for k, v := c.First(); k != nil; k, v = c.Next() {
-				numReads++
-				results.AddCompletedOps(1)
-				if v == nil {
-					return ErrInvalidValue
+			err := func() error {
+				defer func() { results.AddCompletedOps(numReads) }()
+
+				c := tx.Bucket(benchBucketName).Cursor()
+				for k, v := c.First(); k != nil; k, v = c.Next() {
+					numReads++
+					if v == nil {
+						return ErrInvalidValue
+					}
 				}
+
+				return nil
+			}()
+
+			if err != nil {
+				return err
 			}
 
 			if options.WriteMode == "seq" && numReads != options.Iterations {
@@ -1409,14 +1418,23 @@ func (cmd *benchCommand) runReadsRandom(db *bolt.DB, options *BenchOptions, keys
 
 		for {
 			numReads := int64(0)
-			b := tx.Bucket(benchBucketName)
-			for _, key := range keys {
-				v := b.Get(key.key)
-				numReads++
-				results.AddCompletedOps(1)
-				if v == nil {
-					return ErrInvalidValue
+			err := func() error {
+				defer func() { results.AddCompletedOps(numReads) }()
+
+				b := tx.Bucket(benchBucketName)
+				for _, key := range keys {
+					v := b.Get(key.key)
+					numReads++
+					if v == nil {
+						return ErrInvalidValue
+					}
 				}
+
+				return nil
+			}()
+
+			if err != nil {
+				return err
 			}
 
 			if options.WriteMode == "seq" && numReads != options.Iterations {
@@ -1441,11 +1459,11 @@ func (cmd *benchCommand) runReadsSequentialNested(db *bolt.DB, options *BenchOpt
 			numReads := int64(0)
 			var top = tx.Bucket(benchBucketName)
 			if err := top.ForEach(func(name, _ []byte) error {
+				defer func() { results.AddCompletedOps(numReads) }()
 				if b := top.Bucket(name); b != nil {
 					c := b.Cursor()
 					for k, v := c.First(); k != nil; k, v = c.Next() {
 						numReads++
-						results.AddCompletedOps(1)
 						if v == nil {
 							return ErrInvalidValue
 						}
@@ -1476,16 +1494,25 @@ func (cmd *benchCommand) runReadsRandomNested(db *bolt.DB, options *BenchOptions
 
 		for {
 			numReads := int64(0)
-			var top = tx.Bucket(benchBucketName)
-			for _, nestedKey := range nestedKeys {
-				if b := top.Bucket(nestedKey.bucket); b != nil {
-					v := b.Get(nestedKey.key)
-					numReads++
-					results.AddCompletedOps(1)
-					if v == nil {
-						return ErrInvalidValue
+			err := func() error {
+				defer func() { results.AddCompletedOps(numReads) }()
+
+				var top = tx.Bucket(benchBucketName)
+				for _, nestedKey := range nestedKeys {
+					if b := top.Bucket(nestedKey.bucket); b != nil {
+						v := b.Get(nestedKey.key)
+						numReads++
+						if v == nil {
+							return ErrInvalidValue
+						}
 					}
 				}
+
+				return nil
+			}()
+
+			if err != nil {
+				return err
 			}
 
 			if options.WriteMode == "seq-nest" && numReads != options.Iterations {


### PR DESCRIPTION
Currently, the completed operations are added to the read benchmarks one by one, and given that each operation is atomic, it impacts the benchmark's performance. Change to update only once per cycle, with the total number of reads.

Related to #720 