### PR TITLE
Simplify the commands' usage description

### DIFF
--- a/cmd/bbolt/command_inspect.go
+++ b/cmd/bbolt/command_inspect.go
@@ -12,7 +12,7 @@ import (
 
 func newInspectCommand() *cobra.Command {
 	inspectCmd := &cobra.Command{
-		Use:   "inspect",
+		Use:   "inspect <bbolt-file>",
 		Short: "inspect the structure of the database",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bbolt/command_root.go
+++ b/cmd/bbolt/command_root.go
@@ -18,7 +18,7 @@ func NewRootCommand() *cobra.Command {
 
 	rootCmd.AddCommand(
 		newVersionCommand(),
-		newSurgeryCobraCommand(),
+		newSurgeryCommand(),
 		newInspectCommand(),
 		newCheckCommand(),
 	)

--- a/cmd/bbolt/command_surgery.go
+++ b/cmd/bbolt/command_surgery.go
@@ -17,7 +17,7 @@ var (
 	ErrSurgeryFreelistAlreadyExist = errors.New("the file already has freelist, please consider to abandon the freelist to forcibly rebuild it")
 )
 
-func newSurgeryCobraCommand() *cobra.Command {
+func newSurgeryCommand() *cobra.Command {
 	surgeryCmd := &cobra.Command{
 		Use:   "surgery <subcommand>",
 		Short: "surgery related commands",
@@ -52,7 +52,7 @@ func (o *surgeryBaseOptions) Validate() error {
 func newSurgeryRevertMetaPageCommand() *cobra.Command {
 	var o surgeryBaseOptions
 	revertMetaPageCmd := &cobra.Command{
-		Use:   "revert-meta-page <bbolt-file> [options]",
+		Use:   "revert-meta-page <bbolt-file>",
 		Short: "Revert the meta page to revert the changes performed by the latest transaction",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -111,7 +111,7 @@ func (o *surgeryCopyPageOptions) Validate() error {
 func newSurgeryCopyPageCommand() *cobra.Command {
 	var o surgeryCopyPageOptions
 	copyPageCmd := &cobra.Command{
-		Use:   "copy-page <bbolt-file> [options]",
+		Use:   "copy-page <bbolt-file>",
 		Short: "Copy page from the source page Id to the destination page Id",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -175,7 +175,7 @@ func (o *surgeryClearPageOptions) Validate() error {
 func newSurgeryClearPageCommand() *cobra.Command {
 	var o surgeryClearPageOptions
 	clearPageCmd := &cobra.Command{
-		Use:   "clear-page <bbolt-file> [options]",
+		Use:   "clear-page <bbolt-file>",
 		Short: "Clears all elements from the given page, which can be a branch or leaf page",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -242,7 +242,7 @@ func (o *surgeryClearPageElementsOptions) Validate() error {
 func newSurgeryClearPageElementsCommand() *cobra.Command {
 	var o surgeryClearPageElementsOptions
 	clearElementCmd := &cobra.Command{
-		Use:   "clear-page-elements <bbolt-file> [options]",
+		Use:   "clear-page-elements <bbolt-file>",
 		Short: "Clears elements from the given page, which can be a branch or leaf page",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bbolt/command_surgery_freelist.go
+++ b/cmd/bbolt/command_surgery_freelist.go
@@ -26,7 +26,7 @@ func newSurgeryFreelistCommand() *cobra.Command {
 func newSurgeryFreelistAbandonCommand() *cobra.Command {
 	var o surgeryBaseOptions
 	abandonFreelistCmd := &cobra.Command{
-		Use:   "abandon <bbolt-file> [options]",
+		Use:   "abandon <bbolt-file>",
 		Short: "Abandon the freelist from both meta pages",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -61,7 +61,7 @@ func surgeryFreelistAbandonFunc(srcDBPath string, cfg surgeryBaseOptions) error 
 func newSurgeryFreelistRebuildCommand() *cobra.Command {
 	var o surgeryBaseOptions
 	rebuildFreelistCmd := &cobra.Command{
-		Use:   "rebuild <bbolt-file> [options]",
+		Use:   "rebuild <bbolt-file>",
 		Short: "Rebuild the freelist",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/bbolt/command_surgery_meta.go
+++ b/cmd/bbolt/command_surgery_meta.go
@@ -34,7 +34,7 @@ func newSurgeryMetaCommand() *cobra.Command {
 
 func newSurgeryMetaValidateCommand() *cobra.Command {
 	metaValidateCmd := &cobra.Command{
-		Use:   "validate <bbolt-file> [options]",
+		Use:   "validate <bbolt-file>",
 		Short: "Validate both meta pages",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -120,7 +120,7 @@ func (o *surgeryMetaUpdateOptions) Validate() error {
 func newSurgeryMetaUpdateCommand() *cobra.Command {
 	var o surgeryMetaUpdateOptions
 	metaUpdateCmd := &cobra.Command{
-		Use:   "update <bbolt-file> [options]",
+		Use:   "update <bbolt-file>",
 		Short: "Update fields in meta pages",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
 
Old output:
```
$ ./bbolt surgery meta update -h
Update fields in meta pages

Usage:
  bbolt surgery meta update <bbolt-file> [options] [flags]

Flags:
      --fields strings     comma separated list of fields (supported fields: pageSize, root, freelist and pgid) to be updated, and each item is a colon-separated key-value pair
  -h, --help               help for update
      --meta-page uint32   the meta page ID to operate on, valid values are 0 and 1
      --output string      path to the filePath db file
```

New output:

```
$ ./bbolt surgery meta update -h
Update fields in meta pages

Usage:
  bbolt surgery meta update <bbolt-file> [flags]

Flags:
      --fields strings     comma separated list of fields (supported fields: pageSize, root, freelist and pgid) to be updated, and each item is a colon-separated key-value pair
  -h, --help               help for update
      --meta-page uint32   the meta page ID to operate on, valid values are 0 and 1
      --output string      path to the filePath db file
```