### PR TITLE
Rename cobra commands

### DIFF
--- a/cmd/bbolt/command_inspect.go
+++ b/cmd/bbolt/command_inspect.go
@@ -10,7 +10,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-func newInspectCobraCommand() *cobra.Command {
+func newInspectCommand() *cobra.Command {
 	inspectCmd := &cobra.Command{
 		Use:   "inspect",
 		Short: "inspect the structure of the database",

--- a/cmd/bbolt/command_root.go
+++ b/cmd/bbolt/command_root.go
@@ -17,9 +17,9 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	rootCmd.AddCommand(
-		newVersionCobraCommand(),
+		newVersionCommand(),
 		newSurgeryCobraCommand(),
-		newInspectCobraCommand(),
+		newInspectCommand(),
 		newCheckCommand(),
 	)
 

--- a/cmd/bbolt/command_version.go
+++ b/cmd/bbolt/command_version.go
@@ -8,7 +8,7 @@ import (
 	"go.etcd.io/bbolt/version"
 )
 
-func newVersionCobraCommand() *cobra.Command {
+func newVersionCommand() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "print the current version of bbolt",


### PR DESCRIPTION
Remove the `CobraCommand` suffix, renaming them to just `Command`. 

Fixes #731.