### PR TITLE
github/workflows: don't run race tests on user forks

### DIFF
--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   test-linux:
     # this is to prevent arm64 jobs from running at forked projects
-    if: ${{ github.repository == 'etcd-io/bbolt' || startsWith(inputs.runs-on, 'ubuntu') }}
+    if: ${{ github.repository == 'etcd-io/bbolt' || inputs.runs-on == 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Race tests require a larger instance size, which user forks cannot access. By not running them on user forks, contributors won't be notified that their builds are failing due to timeouts trying to run the job, while the tests will still run on etcd-io/bbolt pull requests and commits.

Fixes #751.