### PR TITLE
cmd/bbolt: write bench results to stdout

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1056,11 +1056,11 @@ func (cmd *benchCommand) Run(args ...string) error {
 		benchWriteName := "BenchmarkWrite"
 		benchReadName := "BenchmarkRead"
 		maxLen := max(len(benchReadName), len(benchWriteName))
-		printGoBenchResult(cmd.Stderr, writeResults, maxLen, benchWriteName)
-		printGoBenchResult(cmd.Stderr, readResults, maxLen, benchReadName)
+		printGoBenchResult(cmd.Stdout, writeResults, maxLen, benchWriteName)
+		printGoBenchResult(cmd.Stdout, readResults, maxLen, benchReadName)
 	} else {
-		fmt.Fprintf(cmd.Stderr, "# Write\t%v(ops)\t%v\t(%v/op)\t(%v op/sec)\n", writeResults.CompletedOps(), writeResults.Duration(), writeResults.OpDuration(), writeResults.OpsPerSecond())
-		fmt.Fprintf(cmd.Stderr, "# Read\t%v(ops)\t%v\t(%v/op)\t(%v op/sec)\n", readResults.CompletedOps(), readResults.Duration(), readResults.OpDuration(), readResults.OpsPerSecond())
+		fmt.Fprintf(cmd.Stdout, "# Write\t%v(ops)\t%v\t(%v/op)\t(%v op/sec)\n", writeResults.CompletedOps(), writeResults.Duration(), writeResults.OpDuration(), writeResults.OpsPerSecond())
+		fmt.Fprintf(cmd.Stdout, "# Read\t%v(ops)\t%v\t(%v/op)\t(%v op/sec)\n", readResults.CompletedOps(), readResults.Duration(), readResults.OpDuration(), readResults.OpsPerSecond())
 	}
 	fmt.Fprintln(cmd.Stderr, "")
 

--- a/cmd/bbolt/main_test.go
+++ b/cmd/bbolt/main_test.go
@@ -484,6 +484,7 @@ func TestBenchCommand_Run(t *testing.T) {
 			}
 
 			stderr := m.Stderr.String()
+			stdout := m.Stdout.String()
 			if !strings.Contains(stderr, "starting write benchmark.") || !strings.Contains(stderr, "starting read benchmark.") {
 				t.Fatal(fmt.Errorf("benchmark result does not contain read/write start output:\n%s", stderr))
 			}
@@ -492,8 +493,8 @@ func TestBenchCommand_Run(t *testing.T) {
 				t.Fatal(fmt.Errorf("found iter mismatch in stdout:\n%s", stderr))
 			}
 
-			if !strings.Contains(stderr, "# Write") || !strings.Contains(stderr, "# Read") {
-				t.Fatal(fmt.Errorf("benchmark result does not contain read/write output:\n%s", stderr))
+			if !strings.Contains(stdout, "# Write") || !strings.Contains(stdout, "# Read") {
+				t.Fatal(fmt.Errorf("benchmark result does not contain read/write output:\n%s", stdout))
 			}
 		})
 	}


### PR DESCRIPTION
Follow-up on #765, and work towards #750 and #739.

This PR changes the output of the `bench` results to `stdout` rather than `stderr` for ease of working with the output.

However, I'm unsure if we would consider this a breaking change. If we want to delay this change, I can work around this.