### PR TITLE
[DO NOT REVIERW] try to reproduce the db corruption issue

### DIFF
--- a/concurrent_test.go
+++ b/concurrent_test.go
@@ -100,30 +100,6 @@ func TestConcurrentGenericReadAndWrite(t *testing.T) {
 		testDuration time.Duration
 	}{
 		{
-			name:         "1 worker",
-			workerCount:  1,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
-			name:         "10 workers",
-			workerCount:  10,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
-			name:         "50 workers",
-			workerCount:  50,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
-			name:         "100 workers",
-			workerCount:  100,
-			conf:         conf,
-			testDuration: testDuration,
-		},
-		{
 			name:         "200 workers",
 			workerCount:  200,
 			conf:         conf,
@@ -214,7 +190,10 @@ func concurrentReadAndWrite(t *testing.T,
 // to ensure the test case can be executed on old branches or versions,
 // e.g. `release-1.3` or `1.3.[5-7]`.
 func mustCreateDB(t *testing.T, o *bolt.Options) *bolt.DB {
-	f := filepath.Join(t.TempDir(), "db")
+	f := "./bbolt.db"
+	if err := os.Remove(f); err != nil {
+		t.Logf("Failed to remove %q, error: %v", f, err)
+	}
 
 	return mustOpenDB(t, f, o)
 }


### PR DESCRIPTION
Please do not review this PR.

FYI. I am trying to reproduce the db corruption issue using the following script + this PR.

```
#!/usr/bin/env bash

# Please run this script at the root directory of the bbolt repository
# using command something like below,
#    nohup ./reproduce_corruption.sh > test.log &

set -euo pipefail

go build ./cmd/bbolt/

minwait=100
maxwait=250
for i in {1..10000}
do
    echo
    echo "-----------------------------------"
    echo "Round $i: $(date)"

    rm -f case.log || true

    TEST_CONCURRENT_CASE_DURATION=300s go test -run TestConcurrentGenericReadAndWrite -v > case.log &
    sleep $((minwait + RANDOM % (maxwait-minwait)))

    pid=$(ps -ef | grep bbolt | grep -v grep | awk '{print $2}')
    echo "Killing ${pid}..."
    kill -9 ${pid}
    sleep 10

    echo "Checking db consistency..." 
    ./bbolt page ./bbolt.db 0
    ./bbolt page ./bbolt.db 1
    ./bbolt check ./bbolt.db
    sleep 5
done

echo "All done!"
```


**It has been running for 4 days and 19 hours. NO any issue so far! It's still running.**

```

-----------------------------------
Round 1: Sun  9 Jun 11:33:54 PDT 2024
Killing 385023...
Checking db consistency...
Page ID:    0
Page Type:  meta
Total Size: 4096 bytes
Overflow pages: 0
Version:    2
Page Size:  4096 bytes
Flags:      00000000
Root:       <pgid=9>
Freelist:   <pgid=4>
HWM:        <pgid=1219>
Txn ID:     2812
Checksum:   cc65e26ed4ea7d37

Page ID:    1
Page Type:  meta
Total Size: 4096 bytes
Overflow pages: 0
Version:    2
Page Size:  4096 bytes
Flags:      00000000
Root:       <pgid=9>
Freelist:   <pgid=12>
HWM:        <pgid=1219>
Txn ID:     2811
Checksum:   b50666a0f0774fcc

OK

-----------------------------------
Round 2: Sun  9 Jun 11:36:20 PDT 2024
Killing 385117...
Checking db consistency...
Page ID:    0
Page Type:  meta
Total Size: 4096 bytes
Overflow pages: 0
Version:    2
Page Size:  4096 bytes
Flags:      00000000
Root:       <pgid=17>
Freelist:   <pgid=7>
HWM:        <pgid=1003>
Txn ID:     2710
Checksum:   de3e350417492bcf

Page ID:    1
Page Type:  meta
Total Size: 4096 bytes
Overflow pages: 0
Version:    2
Page Size:  4096 bytes
Flags:      00000000
Root:       <pgid=27>
Freelist:   <pgid=28>
HWM:        <pgid=1014>
Txn ID:     2711
Checksum:   8328e60775bb0806

OK

-----------------------------------
......
-----------------------------------
Round 2193: Fri 14 Jun 06:30:09 PDT 2024

```

cc @fuweid @tjungblu @ivanvc @Elbehery 
