### PR TITLE
change FileMode var formatter to %s

### DIFF
--- a/db.go
+++ b/db.go
@@ -205,7 +205,7 @@ func Open(path string, mode os.FileMode, options *Options) (db *DB, err error) {
 
 	lg := db.Logger()
 	if lg != discardLogger {
-		lg.Infof("Opening db file (%s) with mode %x and with options: %s", path, mode, options)
+		lg.Infof("Opening db file (%s) with mode %s and with options: %s", path, mode, options)
 		defer func() {
 			if err != nil {
 				lg.Errorf("Opening bbolt db (%s) failed: %v", path, err)


### PR DESCRIPTION
Change formatter for `FileMode` var to `%s` as it has implemented Stringer interface and the output is more readable.

Before(formatter is `%x`):
```
Opening db file (default-etcd/member/snap/db) with mode 2d72772d2d2d2d2d2d2d and with options: {Timeout: 0s, NoGrowSync: false, NoFreelistSync: true, PreLoadFreelist: false, FreelistType: , ReadOnly: false, MmapFlags: 8000, InitialMmapSize: 10737418240, PageSize: 0, NoSync: false, OpenFile: 0x0, Mlock: false, Logger: 0xc000398248}
```

After(formatter is `%s`):
```
Opening db file (default-etcd/member/snap/db) with mode -rw------- and with options: {Timeout: 0s, NoGrowSync: false, NoFreelistSync: true, PreLoadFreelist: false, FreelistType: , ReadOnly: false, MmapFlags: 8000, InitialMmapSize: 10737418240, PageSize: 0, NoSync: false, OpenFile: 0x0, Mlock: false, Logger: 0xc0004a8148}
```