### PR TITLE
Explicitly set the pagesize as 4096 for the concurrent test

### DIFF
--- a/concurrent_test.go
+++ b/concurrent_test.go
@@ -165,7 +165,9 @@ func concurrentReadAndWrite(t *testing.T,
 	testDuration time.Duration) {
 
 	t.Log("Preparing db.")
-	db := mustCreateDB(t, nil)
+	db := mustCreateDB(t, &bolt.Options{
+		PageSize: 4096,
+	})
 	defer db.Close()
 	err := db.Update(func(tx *bolt.Tx) error {
 		for i := 0; i < conf.bucketCount; i++ {


### PR DESCRIPTION
Different platforms may have different page size, but the test should be independent to the platforms; so explicitly set the pagesize as 4096.