### PR TITLE
No need to handle freelist as a specical case when freeing a page

### DIFF
--- a/internal/freelist/shared.go
+++ b/internal/freelist/shared.go
@@ -67,9 +67,6 @@ func (t *shared) Free(txid common.Txid, p *common.Page) {
 	allocTxid, ok := t.allocs[p.Id()]
 	if ok {
 		delete(t.allocs, p.Id())
-	} else if p.IsFreelistPage() {
-		// Freelist is always allocated by prior tx.
-		allocTxid = txid - 1
 	}
 
 	for id := p.Id(); id <= p.Id()+common.Pgid(p.Overflow()); id++ {


### PR DESCRIPTION
Read https://github.com/etcd-io/bbolt/pull/67#discussion_r1657120866

When the page ID to be freed isn't included in `f.allocs`, then it means it must be allocated before opening the db this time, and the write transaction is the very first write TXN after opening the db. So it (the page ID to be freed) must be visible to all readonly transactions. We just need to use the default value 0 for such case, in the same way as we did for other page types.

Will rebase this PR once https://github.com/etcd-io/bbolt/pull/775 gets merged.

The existing test cases already cover the sanity test. We will add more dedicated test cases for freelist management later.

cc @tjungblu @fuweid @ivanvc 