### PR TITLE
ensure hashmap init clears maps 

### DIFF
--- a/internal/freelist/array.go
+++ b/internal/freelist/array.go
@@ -101,6 +101,7 @@ func (f *array) mergeSpans(ids common.Pgids) {
 func NewArrayFreelist() Interface {
 	a := &array{
 		shared: newShared(),
+		ids:    []common.Pgid{},
 	}
 	a.Interface = a
 	return a

--- a/internal/freelist/hashmap.go
+++ b/internal/freelist/hashmap.go
@@ -21,22 +21,22 @@ type hashMap struct {
 }
 
 func (f *hashMap) Init(pgids common.Pgids) {
+	// reset the counter when freelist init
+	f.freePagesCount = 0
+	f.freemaps = make(map[uint64]pidSet)
+	f.forwardMap = make(map[common.Pgid]uint64)
+	f.backwardMap = make(map[common.Pgid]uint64)
+
 	if len(pgids) == 0 {
 		return
 	}
-
-	size := uint64(1)
-	start := pgids[0]
-	// reset the counter when freelist init
-	f.freePagesCount = 0
 
 	if !sort.SliceIsSorted([]common.Pgid(pgids), func(i, j int) bool { return pgids[i] < pgids[j] }) {
 		panic("pgids not sorted")
 	}
 
-	f.freemaps = make(map[uint64]pidSet)
-	f.forwardMap = make(map[common.Pgid]uint64)
-	f.backwardMap = make(map[common.Pgid]uint64)
+	size := uint64(1)
+	start := pgids[0]
 
 	for i := 1; i < len(pgids); i++ {
 		// continuous page
@@ -117,7 +117,7 @@ func (f *hashMap) FreeCount() int {
 func (f *hashMap) freePageIds() common.Pgids {
 	count := f.FreeCount()
 	if count == 0 {
-		return nil
+		return common.Pgids{}
 	}
 
 	m := make([]common.Pgid, 0, count)

--- a/internal/freelist/shared.go
+++ b/internal/freelist/shared.go
@@ -167,7 +167,7 @@ func (t *shared) releaseRange(begin, end common.Txid) {
 	if begin > end {
 		return
 	}
-	var m common.Pgids
+	m := common.Pgids{}
 	for tid, txp := range t.pending {
 		if tid < begin || tid > end {
 			continue


### PR DESCRIPTION
This reorders some statements in the hashmap initialization to ensure we always start fresh, even when no pageids were passed to it.

fixes #791

--

Might be better to fix this before #775? would make an easier backport.