### PR TITLE
github/workflows: set top-level file permissions

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,6 +1,6 @@
 ---
 name: Approve GitHub Workflows
-
+permissions: read-all
 on:
   pull_request_target:
     types:

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -1,6 +1,7 @@
 ---
 name: Tests
 on: [push, pull_request]
+permissions: read-all
 jobs:
   test-windows:
     strategy:


### PR DESCRIPTION
The gh-workflow-approve and tests_windows actions didn't specify top-level permissions. This is an improvement towards having a better OpenSSF Scorecard Report score.

Related to etcd-io/etcd#18362