### PR TITLE
[1.3] backport failpoints(resizeFileError, lackOfDiskSpace) and dmflakey on XFS

### DIFF
--- a/.github/workflows/robustness_test.yaml
+++ b/.github/workflows/robustness_test.yaml
@@ -12,6 +12,9 @@ jobs:
         with:
           go-version: ${{ steps.goversion.outputs.goversion }}
       - run: |
+          set -euo pipefail
+          sudo apt-get install -y dmsetup xfsprogs
+
           make gofail-enable
           # build bbolt with failpoint
           go install ./cmd/bbolt

--- a/db.go
+++ b/db.go
@@ -1159,6 +1159,8 @@ func (db *DB) grow(sz int) error {
 	// https://github.com/boltdb/bolt/issues/284
 	if !db.NoGrowSync && !db.readOnly {
 		if runtime.GOOS != "windows" {
+			// gofail: var resizeFileError string
+			// return errors.New(resizeFileError)
 			if err := db.file.Truncate(int64(sz)); err != nil {
 				return fmt.Errorf("file resize error: %s", err)
 			}

--- a/tests/dmflakey/dmflakey.go
+++ b/tests/dmflakey/dmflakey.go
@@ -90,9 +90,9 @@ const (
 // The device-mapper device will be /dev/mapper/$flakeyDevice. And the filesystem
 // image will be created at $dataStorePath/$flakeyDevice.img. By default, the
 // device is available for 2 minutes and size is 10 GiB.
-func InitFlakey(flakeyDevice, dataStorePath string, fsType FSType) (_ Flakey, retErr error) {
+func InitFlakey(flakeyDevice, dataStorePath string, fsType FSType, mkfsOpt string) (_ Flakey, retErr error) {
 	imgPath := filepath.Join(dataStorePath, fmt.Sprintf("%s.img", flakeyDevice))
-	if err := createEmptyFSImage(imgPath, fsType); err != nil {
+	if err := createEmptyFSImage(imgPath, fsType, mkfsOpt); err != nil {
 		return nil, err
 	}
 	defer func() {
@@ -276,7 +276,7 @@ func (f *flakey) Teardown() error {
 
 // createEmptyFSImage creates empty filesystem on dataStorePath folder with
 // default size - 10 GiB.
-func createEmptyFSImage(imgPath string, fsType FSType) error {
+func createEmptyFSImage(imgPath string, fsType FSType, mkfsOpt string) error {
 	if err := validateFSType(fsType); err != nil {
 		return err
 	}
@@ -308,10 +308,16 @@ func createEmptyFSImage(imgPath string, fsType FSType) error {
 			imgPath, defaultImgSize, err)
 	}
 
-	output, err := exec.Command(mkfs, imgPath).CombinedOutput()
+	args := []string{imgPath}
+	if mkfsOpt != "" {
+		splitArgs := strings.Split(mkfsOpt, " ")
+		args = append(splitArgs, imgPath)
+	}
+
+	output, err := exec.Command(mkfs, args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to mkfs.%s on %s (out: %s): %w",
-			fsType, imgPath, string(output), err)
+		return fmt.Errorf("failed to mkfs on %s (%s %v) (out: %s): %w",
+			imgPath, mkfs, args, string(output), err)
 	}
 	return nil
 }

--- a/tests/dmflakey/dmflakey.go
+++ b/tests/dmflakey/dmflakey.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -287,6 +288,10 @@ func createEmptyFSImage(imgPath string, fsType FSType) error {
 
 	if _, err := os.Stat(imgPath); err == nil {
 		return fmt.Errorf("failed to create image because %s already exists", imgPath)
+	}
+
+	if err := os.MkdirAll(path.Dir(imgPath), 0600); err != nil {
+		return fmt.Errorf("failed to ensure parent directory %s: %w", path.Dir(imgPath), err)
 	}
 
 	f, err := os.Create(imgPath)

--- a/tests/failpoint/db_failpoint_test.go
+++ b/tests/failpoint/db_failpoint_test.go
@@ -209,3 +209,31 @@ func TestIssue72(t *testing.T) {
 func idToBytes(id int) []byte {
 	return []byte(fmt.Sprintf("%010d", id))
 }
+
+func TestFailpoint_ResizeFileFail(t *testing.T) {
+	db := btesting.MustCreateDB(t)
+
+	err := gofail.Enable("resizeFileError", `return("resizeFile somehow failed")`)
+	require.NoError(t, err)
+
+	err = db.Fill([]byte("data"), 1, 10000,
+		func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
+		func(tx int, k int) []byte { return make([]byte, 100) },
+	)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "resizeFile somehow failed")
+
+	// It should work after disabling the failpoint.
+	err = gofail.Disable("resizeFileError")
+	require.NoError(t, err)
+	db.MustClose()
+	db.MustReopen()
+
+	err = db.Fill([]byte("data"), 1, 10000,
+		func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
+		func(tx int, k int) []byte { return make([]byte, 100) },
+	)
+
+	require.NoError(t, err)
+}

--- a/tests/robustness/powerfailure_test.go
+++ b/tests/robustness/powerfailure_test.go
@@ -35,8 +35,8 @@ var panicFailpoints = []string{
 	"unmapError",
 }
 
-// TestRestartFromPowerFailure is to test data after unexpected power failure.
-func TestRestartFromPowerFailure(t *testing.T) {
+// TestRestartFromPowerFailureExt4 is to test data after unexpected power failure on ext4.
+func TestRestartFromPowerFailureExt4(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		du           time.Duration
@@ -78,13 +78,69 @@ func TestRestartFromPowerFailure(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			doPowerFailure(t, tc.du, tc.fsMountOpt, tc.useFailpoint)
+			doPowerFailure(t, tc.du, dmflakey.FSTypeEXT4, "", tc.fsMountOpt, tc.useFailpoint)
 		})
 	}
 }
 
-func doPowerFailure(t *testing.T, du time.Duration, fsMountOpt string, useFailpoint bool) {
-	flakey := initFlakeyDevice(t, strings.Replace(t.Name(), "/", "_", -1), dmflakey.FSTypeEXT4, fsMountOpt)
+func TestRestartFromPowerFailureXFS(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		mkfsOpt      string
+		fsMountOpt   string
+		useFailpoint bool
+	}{
+		{
+			name:         "xfs_no_opts",
+			mkfsOpt:      "",
+			fsMountOpt:   "",
+			useFailpoint: true,
+		},
+		{
+			name:         "lazy-log",
+			mkfsOpt:      "-l lazy-count=1",
+			fsMountOpt:   "",
+			useFailpoint: true,
+		},
+		{
+			name:         "odd-allocsize",
+			mkfsOpt:      "",
+			fsMountOpt:   "allocsize=" + fmt.Sprintf("%d", 4096*5),
+			useFailpoint: true,
+		},
+		{
+			name:         "nolargeio",
+			mkfsOpt:      "",
+			fsMountOpt:   "nolargeio",
+			useFailpoint: true,
+		},
+		{
+			name:         "odd-alignment",
+			mkfsOpt:      "-d sunit=1024,swidth=1024",
+			fsMountOpt:   "noalign",
+			useFailpoint: true,
+		},
+		{
+			name:    "openshift-sno-options",
+			mkfsOpt: "-m bigtime=1,finobt=1,rmapbt=0,reflink=1 -i sparse=1 -l lazy-count=1",
+			// openshift also supplies seclabel,relatime,prjquota on RHEL, but that's not supported on our CI
+			// prjquota is only unsupported on our ARM runners.
+			// You can find more information in either the man page with `man xfs` or `man mkfs.xfs`.
+			// Also refer to https://man7.org/linux/man-pages/man8/mkfs.xfs.8.html.
+			fsMountOpt:   "rw,attr2,inode64,logbufs=8,logbsize=32k",
+			useFailpoint: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("mkfs opts: %s", tc.mkfsOpt)
+			t.Logf("mount opts: %s", tc.fsMountOpt)
+			doPowerFailure(t, 5*time.Second, dmflakey.FSTypeXFS, tc.mkfsOpt, tc.fsMountOpt, tc.useFailpoint)
+		})
+	}
+}
+
+func doPowerFailure(t *testing.T, du time.Duration, fsType dmflakey.FSType, mkfsOpt string, fsMountOpt string, useFailpoint bool) {
+	flakey := initFlakeyDevice(t, strings.Replace(t.Name(), "/", "_", -1), fsType, mkfsOpt, fsMountOpt)
 	root := flakey.RootFS()
 
 	dbPath := filepath.Join(root, "boltdb")
@@ -185,10 +241,10 @@ type FlakeyDevice interface {
 }
 
 // initFlakeyDevice returns FlakeyDevice instance with a given filesystem.
-func initFlakeyDevice(t *testing.T, name string, fsType dmflakey.FSType, mntOpt string) FlakeyDevice {
+func initFlakeyDevice(t *testing.T, name string, fsType dmflakey.FSType, mkfsOpt string, mntOpt string) FlakeyDevice {
 	imgDir := t.TempDir()
 
-	flakey, err := dmflakey.InitFlakey(name, imgDir, fsType)
+	flakey, err := dmflakey.InitFlakey(name, imgDir, fsType, mkfsOpt)
 	require.NoError(t, err, "init flakey %s", name)
 	t.Cleanup(func() {
 		assert.NoError(t, flakey.Teardown())
@@ -239,7 +295,7 @@ func (f *flakeyT) PowerFailure(mntOpt string) error {
 	}
 
 	if err := unix.Mount(f.DevicePath(), f.rootDir, string(f.Filesystem()), 0, mntOpt); err != nil {
-		return fmt.Errorf("failed to mount rootfs %s: %w", f.rootDir, err)
+		return fmt.Errorf("failed to mount rootfs %s (%s): %w", f.rootDir, mntOpt, err)
 	}
 	return nil
 }

--- a/tx.go
+++ b/tx.go
@@ -1,6 +1,7 @@
 package bbolt
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -185,6 +186,10 @@ func (tx *Tx) Commit() error {
 
 	// If the high water mark has moved up then attempt to grow the database.
 	if tx.meta.pgid > opgid {
+		_ = errors.New("")
+		// gofail: var lackOfDiskSpace string
+		// tx.rollback()
+		// return errors.New(lackOfDiskSpace)
 		if err := tx.db.grow(int(tx.meta.pgid+1) * tx.db.pageSize); err != nil {
 			tx.rollback()
 			return err


### PR DESCRIPTION
cherry-pick:

* https://github.com/etcd-io/bbolt/pull/482
* https://github.com/etcd-io/bbolt/pull/546 (without using errors package)
* https://github.com/etcd-io/bbolt/pull/658
* https://github.com/etcd-io/bbolt/pull/707 (remove robustness-template and add `apt install xfsprogs` in robustness.yaml)