### PR TITLE
[1.3] tests/robustness: switch to kill if no panic after 10sec

### DIFF
--- a/tests/robustness/powerfailure_test.go
+++ b/tests/robustness/powerfailure_test.go
@@ -150,6 +150,7 @@ func doPowerFailure(t *testing.T, du time.Duration, fsType dmflakey.FSType, mkfs
 		"-path", dbPath,
 		"-count=1000000000",
 		"-batch-size=5", // separate total count into multiple truncation
+		"-value-size=512",
 	}
 
 	logPath := filepath.Join(t.TempDir(), fmt.Sprintf("%s.log", t.Name()))
@@ -196,7 +197,7 @@ func doPowerFailure(t *testing.T, du time.Duration, fsType dmflakey.FSType, mkfs
 
 	select {
 	case <-time.After(10 * time.Second):
-		t.Error("bbolt should stop with panic in seconds")
+		t.Log("bbolt is supposed to be already stopped, but actually not yet; forcibly kill it")
 		assert.NoError(t, cmd.Process.Kill())
 	case err := <-errCh:
 		require.Error(t, err)


### PR DESCRIPTION
If file doesn't grow in 10 sec, bbolt won't trigger the following errors:

* lackOfDiskSpace
* mapError
* resizeFileError
* unmapError

We should switch to kill instead of waiting for panic. In order to trigger these errors, we should increase value size to 512.


(cherry picked from commit 49eb212fa8ab67709ea460df01982504cf7fa4a1)

Fixes: https://github.com/etcd-io/bbolt/pull/816#issuecomment-2277495452