### PR TITLE
[1.3] Rollback alloc map: remove all page ids which are allocated by the txid

### DIFF
--- a/freelist.go
+++ b/freelist.go
@@ -252,6 +252,14 @@ func (f *freelist) rollback(txid txid) {
 	}
 	// Remove pages from pending list and mark as free if allocated by txid.
 	delete(f.pending, txid)
+
+	// Remove pgids which are allocated by this txid
+	for pgid, tid := range f.allocs {
+		if tid == txid {
+			delete(f.allocs, pgid)
+		}
+	}
+
 	f.mergeSpans(m)
 }
 


### PR DESCRIPTION
Backport https://github.com/etcd-io/bbolt/pull/819 to 1.3

cc @fuweid @tjungblu 