### PR TITLE
Add info on how to iterate over existing buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,17 @@ guarantee that they exist for future transactions.
 
 To delete a bucket, simply call the `Tx.DeleteBucket()` function.
 
+You can also iterate over all existing buckets with `Tx.forEach()`:
+
+```go
+db.View(func(tx *bolt.Tx) error {
+	tx.ForEach(func(name []byte, b *bolt.Bucket) error {
+		fmt.Println(string(name))
+		return nil
+	})
+	return nil
+})
+```
 
 ### Using key/value pairs
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ guarantee that they exist for future transactions.
 
 To delete a bucket, simply call the `Tx.DeleteBucket()` function.
 
-You can also iterate over all existing top-level buckets with `Tx.forEach()`:
+You can also iterate over all existing top-level buckets with `Tx.ForEach()`:
 
 ```go
 db.View(func(tx *bolt.Tx) error {
@@ -463,7 +463,7 @@ key and the cursor still points to the first element if present.
 
 If you remove key/value pairs during iteration, the cursor may automatically
 move to the next position if present in current node each time removing a key.
-When you call `c.Next()` after removing a key, it may skip one key/value pair.  
+When you call `c.Next()` after removing a key, it may skip one key/value pair.
 Refer to [pull/611](https://github.com/etcd-io/bbolt/pull/611) to get more detailed info.
 
 During iteration, if the key is non-`nil` but the value is `nil`, that means

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ guarantee that they exist for future transactions.
 
 To delete a bucket, simply call the `Tx.DeleteBucket()` function.
 
-You can also iterate over all existing buckets with `Tx.forEach()`:
+You can also iterate over all existing top-level buckets with `Tx.forEach()`:
 
 ```go
 db.View(func(tx *bolt.Tx) error {


### PR DESCRIPTION
This adds a short description on how to iterate over existing buckets to the README.

This should be helpful for people looking for this particular information (e.g. see #327).
