### PR TITLE
Find new memory pages when node drops disk

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -900,10 +900,9 @@ func (b *Bucket) free() {
 		return
 	}
 
-	var tx = b.tx
 	b.forEachPageNode(func(p *common.Page, n *node, _ int) {
 		if p != nil {
-			tx.db.freelist.Free(tx.meta.Txid(), p)
+			commitCtx.addFreePage(p.Id())
 		} else {
 			n.free()
 		}

--- a/context.go
+++ b/context.go
@@ -1,0 +1,25 @@
+package bbolt
+
+import (
+	"go.etcd.io/bbolt/internal/common"
+)
+
+var (
+	commitCtx = &commitContext{}
+)
+
+type commitContext struct {
+	freePages []common.Pgid
+}
+
+func (c *commitContext) addFreePage(pgid common.Pgid) {
+	c.freePages = append(c.freePages, pgid)
+}
+
+func (c *commitContext) commitFreePages(tx *Tx) {
+	for _, pgid := range c.freePages {
+		tx.db.freelist.Free(tx.meta.Txid(), tx.page(pgid))
+	}
+
+	c.freePages = c.freePages[:0]
+}

--- a/node.go
+++ b/node.go
@@ -316,7 +316,7 @@ func (n *node) spill() error {
 	for _, node := range nodes {
 		// Add node's page to the freelist if it's not new.
 		if node.pgid > 0 {
-			tx.db.freelist.Free(tx.meta.Txid(), tx.page(node.pgid))
+			commitCtx.addFreePage(node.pgid)
 			node.pgid = 0
 		}
 
@@ -493,7 +493,7 @@ func (n *node) dereference() {
 // free adds the node's underlying page to the freelist.
 func (n *node) free() {
 	if n.pgid != 0 {
-		n.bucket.tx.db.freelist.Free(n.bucket.tx.meta.Txid(), n.bucket.tx.page(n.pgid))
+		commitCtx.addFreePage(n.pgid)
 		n.pgid = 0
 	}
 }


### PR DESCRIPTION
When the system is powered off and reset, containerd experiences a panic:
panic: freepages: failed to get all reachable pages (key[0]=(hex)** on leaf page(1229) needs to be < than key of the next element in ancestor(hex)**. Pages stack: [1974,1229])

Every time a commit is made, the essence is that all nodes on the paths involved in the operation (from tree roots to tree leaves) will drop to the disk. If a new memory page is always found when dropping to the disk, and a conflict occurs due to power failure, the tree roots in the two metas must be healthy because the commit drops to the new memory page.

The node involved in the commit operation collects the original pgid and calls tx.db.freelist after the commit Free。

This always allows for the recovery of database files through meta pages, such as "./bbolt surgery revert-meta-page ./db.db --output ./new.db".