### PR TITLE
github: enable ok-to-test for release-1.3 PRs

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -8,6 +8,7 @@ on:
       - synchronize
     branches:
       - main
+      - release-1.3
 
 jobs:
   approve:


### PR DESCRIPTION
Follow-up on https://github.com/etcd-io/bbolt/pull/837#issuecomment-2399847707.

Is this all we need to enable this to work with the release-1.3 branch?