### PR TITLE
Update version to 1.4.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version shows the last bbolt binary version released.
-	Version = "1.4.0-alpha.0"
+	Version = "1.4.0"
 )


### PR DESCRIPTION
Forgot to update the version when releasing v1.4.0. It shouldn't be a big problem, as we don't intentionally release the bbolt binary.

cc @Elbehery  @fuweid @ivanvc @serathius 