### PR TITLE
fix: bump version.go to most recent tag

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version shows the last bbolt binary version released.
-	Version = "1.4.0-alpha.0"
+	Version = "1.4.0"
 )


### PR DESCRIPTION
This PR bumps version.go to most recent tag after last [release](https://github.com/etcd-io/bbolt/pull/895). 

related to https://github.com/etcd-io/bbolt/issues/896 

cc @ivanvc @ahrtr @fuweid 