### PR TITLE
release: add release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# === Function Definitions ===
+function get_gpg_key {
+  local git_email
+  local key_id
+
+  git_email=$(git config --get user.email)
+  key_id=$(gpg --list-keys --with-colons "${git_email}" | awk -F: '/^pub:/ { print $5 }')
+  if [[ -z "${key_id}" ]]; then
+    echo "Failed to load gpg key. Is gpg set up correctly for etcd releases?"
+    return 2
+  fi
+  echo "${key_id}"
+}
+
+# === Main Script Logic ===
+echo "enter release string according to semantic versioning (e.g. v1.2.3)."
+read -r INPUT
+if [[ ! "${INPUT}" =~ ^v[0-9]+.[0-9]+.[0-9]+ ]]; then
+  echo "Expected 'version' param of the form 'v<major-version>.<minor-version>.<patch-version>' but got '${INPUT}'"
+  exit 1
+fi
+
+VERSION=${INPUT#v}
+RELEASE_VERSION="${VERSION}"
+MINOR_VERSION=$(echo "${VERSION}" | cut -d. -f 1-2)
+
+REPOSITORY=${REPOSITORY:-"git@github.com:etcd-io/bbolt.git"}
+REMOTE="${REMOTE:-"origin"}"
+
+remote_tag_exists=$(git ls-remote --tags "${REPOSITORY}" | grep -c "${INPUT}" || true)
+if [ "${remote_tag_exists}" -gt 0 ]; then
+   echo "Release version tag exists on remote."
+   exit 1
+fi
+
+# ensuring the minor-version is identical.
+source_version=$(grep -E "\s+Version\s*=" ./version/version.go | sed -e "s/.*\"\(.*\)\".*/\1/g")
+if [[ "${source_version}" != "${RELEASE_VERSION}" ]]; then
+   source_minor_version=$(echo "${source_version}" | cut -d. -f 1-2)
+   if [[ "${source_minor_version}" != "${MINOR_VERSION}" ]]; then
+     echo "Wrong bbolt minor version in version.go. Expected ${MINOR_VERSION} but got ${source_minor_version}. Aborting."
+     exit 1
+   fi
+fi
+
+# bump 'version.go'.
+echo "Updating version from '${source_version}' to '${RELEASE_VERSION}' in 'version.go'"
+sed -i "s/${source_version}/${RELEASE_VERSION}/g" ./version/version.go
+
+# push 'version.go' to remote.
+echo "committing 'version.go'"
+git add ./version/version.go
+git commit -s -m "Update version to ${VERSION}"
+git push "${REMOTE}" "${INPUT}"
+echo "'version.go' has been committed to remote repo."
+
+# create tag and push to remote.
+echo "Creating new tag for '${INPUT}'"
+key_id=$(get_gpg_key) || return 2
+git tag --local-user "${key_id}" --sign "${INPUT}" --message "${INPUT}"
+git push "${REMOTE}" "${INPUT}"
+echo "Tag '${INPUT}' has been created and pushed to remote repo."
+echo "SUCCESS"


### PR DESCRIPTION
This PR adds `release.sh` script to automate the process of releasing `bbolt` repo.

resolves https://github.com/etcd-io/bbolt/issues/896

Below is output of `release.sh` run 

```
melbeher@melbeher-mac bbolt % ./scripts/release.sh               version_20250212
enter release string according to semantic versioning (e.g. v1.2.3).
v1.4.0-beta.15
fatal: a branch named 'version_20250212' already exists
Updating version from '1.4.0-alpha.0' to '1.4.0-beta.15' in 'version.go'
committing 'version.go'
[version_20250212 234b458] Update version to 1.4.0-beta.15
 1 file changed, 1 insertion(+), 1 deletion(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 12 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (4/4), 379 bytes | 379.00 KiB/s, done.
Total 4 (delta 2), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:Elbehery/bbolt.git
 + 9ad97a4...234b458 version_20250212 -> version_20250212 (forced update)
branch 'version_20250212' set up to track 'origin/version_20250212'.
'version.go' has been committed to remote repo.
Creating new tag for 'v1.4.0-beta.15'
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To github.com:Elbehery/bbolt.git
 * [new tag]         v1.4.0-beta.15 -> v1.4.0-beta.15
Tag 'v1.4.0-beta.15' has been created and pushed to remote repo.
SUCCESS
```