### PR TITLE
Bump go linter 1.24

### DIFF
--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -54,4 +54,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2
         with:
-          version: v1.61.0
+          version: v1.63.4

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -42,7 +42,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@051d91933864810ecd5e2ea2cfd98f6a5bca5347 # v6.3.2
         with:
-          version: v1.61.0
+          version: v1.63.4
 
   coverage:
     needs: ["test-windows"]


### PR DESCRIPTION
 https://github.com/etcd-io/bbolt/pull/907 CI failure is due to linter version used is built using `go1.23`. 

This PR bumps the go-linter version used in CI

@ivanvc @henrybear327 