### PR TITLE
chore: use go-version-file to read go-version from go.mod

### DIFF
--- a/.github/workflows/benchmark-template.yaml
+++ b/.github/workflows/benchmark-template.yaml
@@ -24,11 +24,9 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
-    - id: goversion
-      run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
     - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
       with:
-        go-version: ${{ steps.goversion.outputs.goversion }}
+        go-version-file: go.mod
     - name: Run Benchmarks
       run: |
         BENCHSTAT_OUTPUT_FILE=result.txt make test-benchmark-compare REF=${{ inputs.benchGitRef }}

--- a/.github/workflows/failpoint_test.yaml
+++ b/.github/workflows/failpoint_test.yaml
@@ -10,11 +10,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
+          go-version-file: go.mod
       - run: |
           make gofail-enable
           make test-failpoint

--- a/.github/workflows/robustness_template.yaml
+++ b/.github/workflows/robustness_template.yaml
@@ -24,11 +24,9 @@ jobs:
     runs-on: ${{ fromJson(inputs.runs-on) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
+          go-version-file: go.mod
       - name: test-robustness
         run: |
           set -euo pipefail

--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -22,11 +22,9 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
+          go-version-file: go.mod
       - run: make fmt
       - env:
           TARGET: ${{ matrix.target }}

--- a/.github/workflows/tests_amd64.yaml
+++ b/.github/workflows/tests_amd64.yaml
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
+          go-version-file: go.mod
       - run: make coverage

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -20,11 +20,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
+          go-version-file: go.mod
       - run: make fmt
       - env:
           TARGET: ${{ matrix.target }}
@@ -49,9 +47,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
+          go-version-file: go.mod
       - run: make coverage


### PR DESCRIPTION
#### Description

go-version can be read directly from .go-version or go.mod files using go-version-file in setup-go.

This PR uses .go-version to setup-go and allows the removal 'goversion' steps