### PR TITLE
bump golangci-lint v1.64.5-win

### DIFF
--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -42,7 +42,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
-          version: v1.63.4
+          version: v1.64.5
 
   coverage:
     needs: ["test-windows"]


### PR DESCRIPTION
This PR bumps linter version for windows

ref https://github.com/etcd-io/etcd/issues/19417

cc @ivanvc 