### PR TITLE
chore: enable gofumpt, nakedret and revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,13 +4,55 @@ linters:
   disable-all: true
   enable: # please keep this alphabetized
     - errcheck
-    - gofmt
+    - gofumpt
     - goimports
     - gosimple
     - govet
     - ineffassign
+    - nakedret
+    - revive
     - staticcheck
     - unused
 linters-settings: # please keep this alphabetized
   goimports:
     local-prefixes: go.etcd.io # Put imports beginning with prefix after 3rd-party packages.
+  revive:
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: early-return
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: error-return
+      - name: error-naming
+        disabled: true
+      - name: error-strings
+        disabled: true
+      - name: errorf
+      - name: exported
+      - name: if-return
+        disabled: true
+      - name: increment-decrement
+        disabled: true
+      - name: indent-error-flow
+        disabled: true
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+        disabled: true
+      - name: superfluous-else
+        disabled: true
+        arguments:
+          - "preserveScope"
+      - name: time-naming
+      - name: unexported-return
+        disabled: true
+      - name: use-any
+        disabled: true
+      - name: var-declaration
+        disabled: true
+      - name: var-naming
+        disabled: true

--- a/bucket.go
+++ b/bucket.go
@@ -45,7 +45,7 @@ type Bucket struct {
 
 // newBucket returns a new bucket associated with a transaction.
 func newBucket(tx *Tx) Bucket {
-	var b = Bucket{tx: tx, FillPercent: DefaultFillPercent}
+	b := Bucket{tx: tx, FillPercent: DefaultFillPercent}
 	if tx.writable {
 		b.buckets = make(map[string]*Bucket)
 		b.nodes = make(map[common.Pgid]*node)
@@ -102,7 +102,7 @@ func (b *Bucket) Bucket(name []byte) *Bucket {
 	}
 
 	// Otherwise create a bucket and cache it.
-	var child = b.openBucket(v)
+	child := b.openBucket(v)
 	if b.buckets != nil {
 		b.buckets[string(name)] = child
 	}
@@ -113,7 +113,7 @@ func (b *Bucket) Bucket(name []byte) *Bucket {
 // Helper method that re-interprets a sub-bucket value
 // from a parent into a Bucket
 func (b *Bucket) openBucket(value []byte) *Bucket {
-	var child = newBucket(b.tx)
+	child := newBucket(b.tx)
 
 	// Unaligned access requires a copy to be made.
 	const unalignedMask = unsafe.Alignof(struct {
@@ -182,12 +182,12 @@ func (b *Bucket) CreateBucket(key []byte) (rb *Bucket, err error) {
 	}
 
 	// Create empty, inline bucket.
-	var bucket = Bucket{
+	bucket := Bucket{
 		InBucket:    &common.InBucket{},
 		rootNode:    &node{isLeaf: true},
 		FillPercent: DefaultFillPercent,
 	}
-	var value = bucket.write()
+	value := bucket.write()
 
 	c.node().put(newKey, newKey, value, 0, common.BucketLeafFlag)
 
@@ -240,7 +240,7 @@ func (b *Bucket) CreateBucketIfNotExists(key []byte) (rb *Bucket, err error) {
 	// Return an error if there is an existing non-bucket key.
 	if bytes.Equal(newKey, k) {
 		if (flags & common.BucketLeafFlag) != 0 {
-			var child = b.openBucket(v)
+			child := b.openBucket(v)
 			if b.buckets != nil {
 				b.buckets[string(newKey)] = child
 			}
@@ -251,12 +251,12 @@ func (b *Bucket) CreateBucketIfNotExists(key []byte) (rb *Bucket, err error) {
 	}
 
 	// Create empty, inline bucket.
-	var bucket = Bucket{
+	bucket := Bucket{
 		InBucket:    &common.InBucket{},
 		rootNode:    &node{isLeaf: true},
 		FillPercent: DefaultFillPercent,
 	}
-	var value = bucket.write()
+	value := bucket.write()
 
 	c.node().put(newKey, newKey, value, 0, common.BucketLeafFlag)
 
@@ -716,7 +716,7 @@ func (b *Bucket) forEachPageNode(fn func(*common.Page, *node, int)) {
 }
 
 func (b *Bucket) _forEachPageNode(pgId common.Pgid, depth int, fn func(*common.Page, *node, int)) {
-	var p, n = b.pageNode(pgId)
+	p, n := b.pageNode(pgId)
 
 	// Execute function.
 	fn(p, n, depth)
@@ -756,7 +756,7 @@ func (b *Bucket) spill() error {
 
 			// Update the child bucket header in this bucket.
 			value = make([]byte, unsafe.Sizeof(common.InBucket{}))
-			var bucket = (*common.InBucket)(unsafe.Pointer(&value[0]))
+			bucket := (*common.InBucket)(unsafe.Pointer(&value[0]))
 			*bucket = *child.InBucket
 		}
 
@@ -766,7 +766,7 @@ func (b *Bucket) spill() error {
 		}
 
 		// Update parent node.
-		var c = b.Cursor()
+		c := b.Cursor()
 		k, _, flags := c.seek([]byte(name))
 		if !bytes.Equal([]byte(name), k) {
 			panic(fmt.Sprintf("misplaced bucket header: %x -> %x", []byte(name), k))
@@ -800,7 +800,7 @@ func (b *Bucket) spill() error {
 // inlineable returns true if a bucket is small enough to be written inline
 // and if it contains no subbuckets. Otherwise, returns false.
 func (b *Bucket) inlineable() bool {
-	var n = b.rootNode
+	n := b.rootNode
 
 	// Bucket must only contain a single leaf node.
 	if n == nil || !n.isLeaf {
@@ -809,7 +809,7 @@ func (b *Bucket) inlineable() bool {
 
 	// Bucket is not inlineable if it contains subbuckets or if it goes beyond
 	// our threshold for inline bucket size.
-	var size = common.PageHeaderSize
+	size := common.PageHeaderSize
 	for _, inode := range n.inodes {
 		size += common.LeafPageElementSize + uintptr(len(inode.Key())) + uintptr(len(inode.Value()))
 
@@ -831,15 +831,15 @@ func (b *Bucket) maxInlineBucketSize() uintptr {
 // write allocates and writes a bucket to a byte slice.
 func (b *Bucket) write() []byte {
 	// Allocate the appropriate size.
-	var n = b.rootNode
-	var value = make([]byte, common.BucketHeaderSize+n.size())
+	n := b.rootNode
+	value := make([]byte, common.BucketHeaderSize+n.size())
 
 	// Write a bucket header.
-	var bucket = (*common.InBucket)(unsafe.Pointer(&value[0]))
+	bucket := (*common.InBucket)(unsafe.Pointer(&value[0]))
 	*bucket = *b.InBucket
 
 	// Convert byte slice to a fake page and write the root node.
-	var p = (*common.Page)(unsafe.Pointer(&value[common.BucketHeaderSize]))
+	p := (*common.Page)(unsafe.Pointer(&value[common.BucketHeaderSize]))
 	n.write(p)
 
 	return value
@@ -873,7 +873,7 @@ func (b *Bucket) node(pgId common.Pgid, parent *node) *node {
 	}
 
 	// Use the inline page if this is an inline bucket.
-	var p = b.page
+	p := b.page
 	if p == nil {
 		p = b.tx.page(pgId)
 	} else {
@@ -900,7 +900,7 @@ func (b *Bucket) free() {
 		return
 	}
 
-	var tx = b.tx
+	tx := b.tx
 	b.forEachPageNode(func(p *common.Page, n *node, _ int) {
 		if p != nil {
 			tx.db.freelist.Free(tx.meta.Txid(), p)
@@ -993,7 +993,7 @@ func (s *BucketStats) Add(other BucketStats) {
 
 // cloneBytes returns a copy of a given slice.
 func cloneBytes(v []byte) []byte {
-	var clone = make([]byte, len(v))
+	clone := make([]byte, len(v))
 	copy(clone, v)
 	return clone
 }

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -509,7 +509,7 @@ func TestBucket_Nested(t *testing.T) {
 
 	// Cause a split.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		var b = tx.Bucket([]byte("widgets"))
+		b := tx.Bucket([]byte("widgets"))
 		for i := 0; i < 10000; i++ {
 			if err := b.Put([]byte(strconv.Itoa(i)), []byte(strconv.Itoa(i))); err != nil {
 				t.Fatal(err)
@@ -523,7 +523,7 @@ func TestBucket_Nested(t *testing.T) {
 
 	// Insert into widgets/foo/baz.
 	if err := db.Update(func(tx *bolt.Tx) error {
-		var b = tx.Bucket([]byte("widgets"))
+		b := tx.Bucket([]byte("widgets"))
 		if err := b.Bucket([]byte("foo")).Put([]byte("baz"), []byte("yyyy")); err != nil {
 			t.Fatal(err)
 		}
@@ -535,7 +535,7 @@ func TestBucket_Nested(t *testing.T) {
 
 	// Verify.
 	if err := db.View(func(tx *bolt.Tx) error {
-		var b = tx.Bucket([]byte("widgets"))
+		b := tx.Bucket([]byte("widgets"))
 		if v := b.Bucket([]byte("foo")).Get([]byte("baz")); !bytes.Equal(v, []byte("yyyy")) {
 			t.Fatalf("unexpected value: %v", v)
 		}
@@ -1283,7 +1283,8 @@ func TestBucket_Stats(t *testing.T) {
 				1*10 + 2*90 + 3*400 + longKeyLength, // leaf values: 10 * 1digit, 90*2digits, ...
 			BucketN:           1,
 			InlineBucketN:     0,
-			InlineBucketInuse: 0},
+			InlineBucketInuse: 0,
+		},
 		16384: {
 			BranchPageN:     1,
 			BranchOverflowN: 0,
@@ -1301,7 +1302,8 @@ func TestBucket_Stats(t *testing.T) {
 				1*10 + 2*90 + 3*400 + longKeyLength, // leaf values: 10 * 1digit, 90*2digits, ...
 			BucketN:           1,
 			InlineBucketN:     0,
-			InlineBucketInuse: 0},
+			InlineBucketInuse: 0,
+		},
 		65536: {
 			BranchPageN:     1,
 			BranchOverflowN: 0,
@@ -1319,7 +1321,8 @@ func TestBucket_Stats(t *testing.T) {
 				1*10 + 2*90 + 3*400 + longKeyLength, // leaf values: 10 * 1digit, 90*2digits, ...
 			BucketN:           1,
 			InlineBucketN:     0,
-			InlineBucketInuse: 0},
+			InlineBucketInuse: 0,
+		},
 	}
 
 	if err := db.View(func(tx *bolt.Tx) error {
@@ -1775,7 +1778,8 @@ func TestBucket_Stats_Large(t *testing.T) {
 			LeafInuse:         2596916,
 			BucketN:           1,
 			InlineBucketN:     0,
-			InlineBucketInuse: 0},
+			InlineBucketInuse: 0,
+		},
 		16384: {
 			BranchPageN:       1,
 			BranchOverflowN:   0,
@@ -1789,7 +1793,8 @@ func TestBucket_Stats_Large(t *testing.T) {
 			LeafInuse:         2582452,
 			BucketN:           1,
 			InlineBucketN:     0,
-			InlineBucketInuse: 0},
+			InlineBucketInuse: 0,
+		},
 		65536: {
 			BranchPageN:       1,
 			BranchOverflowN:   0,
@@ -1803,7 +1808,8 @@ func TestBucket_Stats_Large(t *testing.T) {
 			LeafInuse:         2578948,
 			BucketN:           1,
 			InlineBucketN:     0,
-			InlineBucketInuse: 0},
+			InlineBucketInuse: 0,
+		},
 	}
 
 	if err := db.View(func(tx *bolt.Tx) error {
@@ -2021,7 +2027,7 @@ func BenchmarkBucket_CreateBucketIfNotExists(b *testing.B) {
 
 func ExampleBucket_Put() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2064,7 +2070,7 @@ func ExampleBucket_Put() {
 
 func ExampleBucket_Delete() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2122,7 +2128,7 @@ func ExampleBucket_Delete() {
 
 func ExampleBucket_ForEach() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/bbolt/command_check.go
+++ b/cmd/bbolt/command_check.go
@@ -39,7 +39,7 @@ func checkFunc(cmd *cobra.Command, dbPath string, cfg checkOptions) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(dbPath, 0600, &bolt.Options{
+	db, err := bolt.Open(dbPath, 0o600, &bolt.Options{
 		ReadOnly:        true,
 		PreLoadFreelist: true,
 	})

--- a/cmd/bbolt/command_check_test.go
+++ b/cmd/bbolt/command_check_test.go
@@ -41,7 +41,6 @@ func TestCheckCommand_Run(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			t.Log("Creating sample DB")
 			db := btesting.MustCreateDB(t)
 			db.Close()

--- a/cmd/bbolt/command_inspect.go
+++ b/cmd/bbolt/command_inspect.go
@@ -28,7 +28,7 @@ func inspectFunc(srcDBPath string) error {
 		return err
 	}
 
-	db, err := bolt.Open(srcDBPath, 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(srcDBPath, 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}

--- a/cmd/bbolt/command_surgery.go
+++ b/cmd/bbolt/command_surgery.go
@@ -13,9 +13,7 @@ import (
 	"go.etcd.io/bbolt/internal/surgeon"
 )
 
-var (
-	ErrSurgeryFreelistAlreadyExist = errors.New("the file already has freelist, please consider to abandon the freelist to forcibly rebuild it")
-)
+var ErrSurgeryFreelistAlreadyExist = errors.New("the file already has freelist, please consider to abandon the freelist to forcibly rebuild it")
 
 func newSurgeryCommand() *cobra.Command {
 	surgeryCmd := &cobra.Command{

--- a/cmd/bbolt/command_surgery_meta.go
+++ b/cmd/bbolt/command_surgery_meta.go
@@ -235,7 +235,7 @@ func ReadMetaPageAt(dbPath string, metaPageId uint32, pageSize uint32) (*common.
 		return nil, nil, fmt.Errorf("invalid metaPageId: %d", metaPageId)
 	}
 
-	f, err := os.OpenFile(dbPath, os.O_RDONLY, 0444)
+	f, err := os.OpenFile(dbPath, os.O_RDONLY, 0o444)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -260,7 +260,7 @@ func writeMetaPageAt(dbPath string, buf []byte, metaPageId uint32, pageSize uint
 		return fmt.Errorf("invalid metaPageId: %d", metaPageId)
 	}
 
-	f, err := os.OpenFile(dbPath, os.O_RDWR, 0666)
+	f, err := os.OpenFile(dbPath, os.O_RDWR, 0o666)
 	if err != nil {
 		return err
 	}

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -212,7 +212,7 @@ func (cmd *infoCommand) Run(args ...string) error {
 	}
 
 	// Open the database.
-	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -572,7 +572,7 @@ func (cmd *pagesCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0600, &bolt.Options{
+	db, err := bolt.Open(path, 0o600, &bolt.Options{
 		ReadOnly:        true,
 		PreLoadFreelist: true,
 	})
@@ -665,7 +665,7 @@ func (cmd *statsCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -796,7 +796,7 @@ func (cmd *bucketsCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -860,7 +860,7 @@ func (cmd *keysCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -948,7 +948,7 @@ func (cmd *getCommand) Run(args ...string) error {
 	}
 
 	// Open database.
-	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -1019,7 +1019,7 @@ func (cmd *benchCommand) Run(args ...string) error {
 	}
 
 	// Create database.
-	db, err := bolt.Open(options.Path, 0600, nil)
+	db, err := bolt.Open(options.Path, 0o600, nil)
 	if err != nil {
 		return err
 	}
@@ -1162,7 +1162,7 @@ func (cmd *benchCommand) runWrites(db *bolt.DB, options *BenchOptions, results *
 }
 
 func (cmd *benchCommand) runWritesSequential(db *bolt.DB, options *BenchOptions, results *BenchResults) ([]nestedKey, error) {
-	var i = uint32(0)
+	i := uint32(0)
 	return cmd.runWritesWithSource(db, options, results, func() uint32 { i++; return i })
 }
 
@@ -1171,7 +1171,7 @@ func (cmd *benchCommand) runWritesRandom(db *bolt.DB, options *BenchOptions, res
 }
 
 func (cmd *benchCommand) runWritesSequentialNested(db *bolt.DB, options *BenchOptions, results *BenchResults) ([]nestedKey, error) {
-	var i = uint32(0)
+	i := uint32(0)
 	return cmd.runWritesNestedWithSource(db, options, results, func() uint32 { i++; return i })
 }
 
@@ -1244,8 +1244,8 @@ func (cmd *benchCommand) runWritesNestedWithSource(db *bolt.DB, options *BenchOp
 
 			fmt.Fprintf(cmd.Stderr, "Starting write iteration %d\n", i)
 			for j := int64(0); j < options.BatchSize; j++ {
-				var key = make([]byte, options.KeySize)
-				var value = make([]byte, options.ValueSize)
+				key := make([]byte, options.KeySize)
+				value := make([]byte, options.ValueSize)
 
 				// Generate key as uint32.
 				binary.BigEndian.PutUint32(key, keySource())
@@ -1334,7 +1334,6 @@ func (cmd *benchCommand) runReadsSequential(db *bolt.DB, options *BenchOptions, 
 
 				return nil
 			}()
-
 			if err != nil {
 				return err
 			}
@@ -1373,7 +1372,6 @@ func (cmd *benchCommand) runReadsRandom(db *bolt.DB, options *BenchOptions, keys
 
 				return nil
 			}()
-
 			if err != nil {
 				return err
 			}
@@ -1398,7 +1396,7 @@ func (cmd *benchCommand) runReadsSequentialNested(db *bolt.DB, options *BenchOpt
 
 		for {
 			numReads := int64(0)
-			var top = tx.Bucket(benchBucketName)
+			top := tx.Bucket(benchBucketName)
 			if err := top.ForEach(func(name, _ []byte) error {
 				defer func() { results.AddCompletedOps(numReads) }()
 				if b := top.Bucket(name); b != nil {
@@ -1438,7 +1436,7 @@ func (cmd *benchCommand) runReadsRandomNested(db *bolt.DB, options *BenchOptions
 			err := func() error {
 				defer func() { results.AddCompletedOps(numReads) }()
 
-				var top = tx.Bucket(benchBucketName)
+				top := tx.Bucket(benchBucketName)
 				for _, nestedKey := range nestedKeys {
 					if b := top.Bucket(nestedKey.bucket); b != nil {
 						v := b.Get(nestedKey.key)
@@ -1451,7 +1449,6 @@ func (cmd *benchCommand) runReadsRandomNested(db *bolt.DB, options *BenchOptions
 
 				return nil
 			}()
-
 			if err != nil {
 				return err
 			}
@@ -1609,7 +1606,7 @@ func (r *BenchResults) OpDuration() time.Duration {
 
 // Returns average number of read/write operations that can be performed per second.
 func (r *BenchResults) OpsPerSecond() int {
-	var op = r.OpDuration()
+	op := r.OpDuration()
 	if op == 0 {
 		return 0
 	}
@@ -1714,7 +1711,7 @@ func (cmd *compactCommand) Run(args ...string) (err error) {
 	initialSize := fi.Size()
 
 	// Open source database.
-	src, err := bolt.Open(cmd.SrcPath, 0400, &bolt.Options{ReadOnly: true})
+	src, err := bolt.Open(cmd.SrcPath, 0o400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -1781,7 +1778,7 @@ func CmdKvStringer() bolt.KVStringer {
 }
 
 func findLastBucket(tx *bolt.Tx, bucketNames []string) (*bolt.Bucket, error) {
-	var lastbucket *bolt.Bucket = tx.Bucket([]byte(bucketNames[0]))
+	lastbucket := tx.Bucket([]byte(bucketNames[0]))
 	if lastbucket == nil {
 		return nil, berrors.ErrBucketNotFound
 	}

--- a/cmd/bbolt/main_test.go
+++ b/cmd/bbolt/main_test.go
@@ -691,7 +691,7 @@ func fillBucket(b *bolt.Bucket, prefix []byte) error {
 }
 
 func chkdb(path string) ([]byte, error) {
-	db, err := bolt.Open(path, 0600, &bolt.Options{ReadOnly: true})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}

--- a/concurrent_test.go
+++ b/concurrent_test.go
@@ -162,8 +162,8 @@ func concurrentTestDuration(t *testing.T) time.Duration {
 func concurrentReadAndWrite(t *testing.T,
 	workerCount int,
 	conf concurrentConfig,
-	testDuration time.Duration) {
-
+	testDuration time.Duration,
+) {
 	t.Log("Preparing db.")
 	db := mustCreateDB(t, &bolt.Options{
 		PageSize: 4096,
@@ -244,7 +244,7 @@ func mustOpenDB(t *testing.T, dbPath string, o *bolt.Options) *bolt.DB {
 
 	o.FreelistType = freelistType
 
-	db, err := bolt.Open(dbPath, 0600, o)
+	db, err := bolt.Open(dbPath, 0o600, o)
 	require.NoError(t, err)
 
 	return db
@@ -275,7 +275,8 @@ func runWorkers(t *testing.T,
 	db *bolt.DB,
 	workerCount int,
 	conf concurrentConfig,
-	testDuration time.Duration) historyRecords {
+	testDuration time.Duration,
+) historyRecords {
 	stopCh := make(chan struct{}, 1)
 	errCh := make(chan error, workerCount)
 
@@ -611,7 +612,7 @@ func copyFile(srcPath, dstPath string) error {
 func persistHistoryRecords(t *testing.T, rs historyRecords, path string) {
 	recordFilePath := filepath.Join(path, "history_records.json")
 	t.Logf("Saving history records to %s", recordFilePath)
-	recordFile, err := os.OpenFile(recordFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	recordFile, err := os.OpenFile(recordFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o755)
 	require.NoError(t, err)
 	defer recordFile.Close()
 	encoder := json.NewEncoder(recordFile)
@@ -637,7 +638,7 @@ func testResultsDirectory(t *testing.T) string {
 	err = os.RemoveAll(path)
 	require.NoError(t, err)
 
-	err = os.MkdirAll(path, 0700)
+	err = os.MkdirAll(path, 0o700)
 	require.NoError(t, err)
 
 	return path
@@ -798,7 +799,6 @@ func TestConcurrentRepeatableRead(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			t.Log("Preparing db.")
 			var (
 				bucket = []byte("data")

--- a/cursor.go
+++ b/cursor.go
@@ -169,7 +169,7 @@ func (c *Cursor) seek(seek []byte) (key []byte, value []byte, flags uint32) {
 func (c *Cursor) goToFirstElementOnTheStack() {
 	for {
 		// Exit when we hit a leaf page.
-		var ref = &c.stack[len(c.stack)-1]
+		ref := &c.stack[len(c.stack)-1]
 		if ref.isLeaf() {
 			break
 		}
@@ -204,7 +204,7 @@ func (c *Cursor) last() {
 		}
 		p, n := c.bucket.pageNode(pgId)
 
-		var nextRef = elemRef{page: p, node: n}
+		nextRef := elemRef{page: p, node: n}
 		nextRef.index = nextRef.count() - 1
 		c.stack = append(c.stack, nextRef)
 	}
@@ -396,7 +396,7 @@ func (c *Cursor) node() *node {
 	}
 
 	// Start from root and traverse down the hierarchy.
-	var n = c.stack[0].node
+	n := c.stack[0].node
 	if n == nil {
 		n = c.bucket.node(c.stack[0].page.Id(), nil)
 	}

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -301,7 +301,7 @@ func TestCursor_Delete(t *testing.T) {
 func TestCursor_Seek_Large(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
-	var count = 10000
+	count := 10000
 
 	// Insert every other key between 0 and $count.
 	if err := db.Update(func(tx *bolt.Tx) error {
@@ -706,7 +706,7 @@ func TestCursor_QuickCheck(t *testing.T) {
 		sort.Sort(items)
 
 		// Iterate over all items and check consistency.
-		var index = 0
+		index := 0
 		tx, err = db.Begin(false)
 		if err != nil {
 			t.Fatal(err)
@@ -764,7 +764,7 @@ func TestCursor_QuickCheck_Reverse(t *testing.T) {
 		sort.Sort(revtestdata(items))
 
 		// Iterate over all items and check consistency.
-		var index = 0
+		index := 0
 		tx, err = db.Begin(false)
 		if err != nil {
 			t.Fatal(err)
@@ -877,7 +877,7 @@ func TestCursor_QuickCheck_BucketsOnly_Reverse(t *testing.T) {
 
 func ExampleCursor() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -931,7 +931,7 @@ func ExampleCursor() {
 
 func ExampleCursor_reverse() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/db.go
+++ b/db.go
@@ -332,9 +332,7 @@ func Open(path string, mode os.FileMode, options *Options) (db *DB, err error) {
 // to read the first meta page firstly. If the first page is invalid,
 // then it tries to read the second page using the default page size.
 func (db *DB) getPageSize() (int, error) {
-	var (
-		meta0CanRead, meta1CanRead bool
-	)
+	var meta0CanRead, meta1CanRead bool
 
 	// Read the first meta page to determine the page size.
 	if pgSize, canRead, err := db.getPageSizeFromFirstMeta(); err != nil {
@@ -466,7 +464,7 @@ func (db *DB) mmap(minsz int) (err error) {
 		lg.Errorf("getting file size failed: %w", err)
 		return err
 	}
-	var size = fileSize
+	size := fileSize
 	if size < minsz {
 		size = minsz
 	}
@@ -1026,7 +1024,7 @@ func (b *batch) run() {
 
 retry:
 	for len(b.calls) > 0 {
-		var failIdx = -1
+		failIdx := -1
 		err := b.db.Update(func(tx *Tx) error {
 			for i, c := range b.calls {
 				if err := safelyCall(c.fn, tx); err != nil {
@@ -1170,7 +1168,7 @@ func (db *DB) allocate(txid common.Txid, count int) (*common.Page, error) {
 
 	// Resize mmap() if we're at the end.
 	p.SetId(db.rwtx.meta.Pgid())
-	var minsz = int((p.Id()+common.Pgid(count))+1) * db.pageSize
+	minsz := int((p.Id()+common.Pgid(count))+1) * db.pageSize
 	if minsz >= db.datasz {
 		if err := db.mmap(minsz); err != nil {
 			if err == berrors.ErrMaxSizeReached {
@@ -1364,7 +1362,6 @@ func (o *Options) String() string {
 
 	return fmt.Sprintf("{Timeout: %s, NoGrowSync: %t, NoFreelistSync: %t, PreLoadFreelist: %t, FreelistType: %s, ReadOnly: %t, MmapFlags: %x, InitialMmapSize: %d, PageSize: %d, MaxSize: %d, NoSync: %t, OpenFile: %p, Mlock: %t, Logger: %p}",
 		o.Timeout, o.NoGrowSync, o.NoFreelistSync, o.PreLoadFreelist, o.FreelistType, o.ReadOnly, o.MmapFlags, o.InitialMmapSize, o.PageSize, o.MaxSize, o.NoSync, o.OpenFile, o.Mlock, o.Logger)
-
 }
 
 // DefaultOptions represent the options used if nil options are passed into Open().

--- a/db_test.go
+++ b/db_test.go
@@ -50,7 +50,7 @@ func TestOpen(t *testing.T) {
 	path := tempfile()
 	defer os.RemoveAll(path)
 
-	db, err := bolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		t.Fatal(err)
 	} else if db == nil {
@@ -86,7 +86,7 @@ func TestOpen_MultipleGoroutines(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				db, err := bolt.Open(path, 0600, nil)
+				db, err := bolt.Open(path, 0o600, nil)
 				if err != nil {
 					errCh <- err
 					return
@@ -109,7 +109,7 @@ func TestOpen_MultipleGoroutines(t *testing.T) {
 
 // Ensure that opening a database with a blank path returns an error.
 func TestOpen_ErrPathRequired(t *testing.T) {
-	_, err := bolt.Open("", 0600, nil)
+	_, err := bolt.Open("", 0o600, nil)
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -117,7 +117,7 @@ func TestOpen_ErrPathRequired(t *testing.T) {
 
 // Ensure that opening a database with a bad path returns an error.
 func TestOpen_ErrNotExists(t *testing.T) {
-	_, err := bolt.Open(filepath.Join(tempfile(), "bad-path"), 0600, nil)
+	_, err := bolt.Open(filepath.Join(tempfile(), "bad-path"), 0o600, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -139,7 +139,7 @@ func TestOpen_ErrInvalid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := bolt.Open(path, 0600, nil); err != berrors.ErrInvalid {
+	if _, err := bolt.Open(path, 0o600, nil); err != berrors.ErrInvalid {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -170,12 +170,12 @@ func TestOpen_ErrVersionMismatch(t *testing.T) {
 	meta0.version++
 	meta1 := (*meta)(unsafe.Pointer(&buf[pageSize+pageHeaderSize]))
 	meta1.version++
-	if err := os.WriteFile(path, buf, 0666); err != nil {
+	if err := os.WriteFile(path, buf, 0o666); err != nil {
 		t.Fatal(err)
 	}
 
 	// Reopen data file.
-	if _, err := bolt.Open(path, 0600, nil); err != berrors.ErrVersionMismatch {
+	if _, err := bolt.Open(path, 0o600, nil); err != berrors.ErrVersionMismatch {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -206,12 +206,12 @@ func TestOpen_ErrChecksum(t *testing.T) {
 	meta0.pgid++
 	meta1 := (*meta)(unsafe.Pointer(&buf[pageSize+pageHeaderSize]))
 	meta1.pgid++
-	if err := os.WriteFile(path, buf, 0666); err != nil {
+	if err := os.WriteFile(path, buf, 0o666); err != nil {
 		t.Fatal(err)
 	}
 
 	// Reopen data file.
-	if _, err := bolt.Open(path, 0600, nil); err != berrors.ErrChecksum {
+	if _, err := bolt.Open(path, 0o600, nil); err != berrors.ErrChecksum {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -234,7 +234,7 @@ func TestOpen_ReadPageSize_FromMeta1_OS(t *testing.T) {
 	// Rewrite first meta page.
 	meta0 := (*meta)(unsafe.Pointer(&buf[pageHeaderSize]))
 	meta0.pgid++
-	if err := os.WriteFile(path, buf, 0666); err != nil {
+	if err := os.WriteFile(path, buf, 0o666); err != nil {
 		t.Fatal(err)
 	}
 
@@ -265,7 +265,7 @@ func TestOpen_ReadPageSize_FromMeta1_Given(t *testing.T) {
 			t.Logf("#%d: Intentionally corrupt the first meta page for pageSize %d", i, givenPageSize)
 			meta0 := (*meta)(unsafe.Pointer(&buf[pageHeaderSize]))
 			meta0.pgid++
-			err = os.WriteFile(path, buf, 0666)
+			err = os.WriteFile(path, buf, 0o666)
 			require.NoError(t, err)
 		}
 
@@ -367,7 +367,7 @@ func TestOpen_Size_Large(t *testing.T) {
 	}
 
 	// Reopen database, update, and check size again.
-	db0, err := bolt.Open(path, 0600, nil)
+	db0, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -397,7 +397,7 @@ func TestOpen_Check(t *testing.T) {
 	path := tempfile()
 	defer os.RemoveAll(path)
 
-	db, err := bolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +408,7 @@ func TestOpen_Check(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	db, err = bolt.Open(path, 0600, nil)
+	db, err = bolt.Open(path, 0o600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +430,7 @@ func TestOpen_FileTooSmall(t *testing.T) {
 	path := tempfile()
 	defer os.RemoveAll(path)
 
-	db, err := bolt.Open(path, 0600, nil)
+	db, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,7 +444,7 @@ func TestOpen_FileTooSmall(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = bolt.Open(path, 0600, nil)
+	_, err = bolt.Open(path, 0o600, nil)
 	if err == nil || !strings.Contains(err.Error(), "file size too small") {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -461,7 +461,7 @@ func TestDB_Open_InitialMmapSize(t *testing.T) {
 	initMmapSize := 1 << 30  // 1GB
 	testWriteSize := 1 << 27 // 134MB
 
-	db, err := bolt.Open(path, 0600, &bolt.Options{InitialMmapSize: initMmapSize})
+	db, err := bolt.Open(path, 0o600, &bolt.Options{InitialMmapSize: initMmapSize})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func TestDB_Open_ReadOnly(t *testing.T) {
 
 	f := db.Path()
 	o := &bolt.Options{ReadOnly: true}
-	readOnlyDB, err := bolt.Open(f, 0600, o)
+	readOnlyDB, err := bolt.Open(f, 0o600, o)
 	if err != nil {
 		panic(err)
 	}
@@ -566,7 +566,7 @@ func TestDB_Open_ReadOnly(t *testing.T) {
 
 func TestDB_Open_ReadOnly_NoCreate(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "db")
-	_, err := bolt.Open(f, 0600, &bolt.Options{ReadOnly: true})
+	_, err := bolt.Open(f, 0o600, &bolt.Options{ReadOnly: true})
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
@@ -691,7 +691,7 @@ func TestDB_Concurrent_WriteTo_and_ConsistentRead(t *testing.T) {
 		defer wg.Done()
 		time.Sleep(time.Duration(rand.Intn(200)+10) * time.Millisecond)
 		f := filepath.Join(t.TempDir(), fmt.Sprintf("%d-bolt-", round))
-		err := tx.CopyFile(f, 0600)
+		err := tx.CopyFile(f, 0o600)
 		require.NoError(t, err)
 
 		// read all the data
@@ -1222,7 +1222,7 @@ func TestDB_Batch_Panic(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
 	var sentinel int
-	var bork = &sentinel
+	bork := &sentinel
 	var problem interface{}
 	var err error
 
@@ -1549,7 +1549,7 @@ func TestDB_MaxSizeExceededDoesNotGrow(t *testing.T) {
 
 func ExampleDB_Update() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1589,7 +1589,7 @@ func ExampleDB_Update() {
 
 func ExampleDB_View() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1632,7 +1632,7 @@ func ExampleDB_View() {
 
 func ExampleDB_Begin() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1832,7 +1832,7 @@ func BenchmarkDBBatchManual10x100(b *testing.B) {
 }
 
 func validateBatchBench(b *testing.B, db *btesting.DB) {
-	var rollback = errors.New("sentinel error to cause rollback")
+	rollback := errors.New("sentinel error to cause rollback")
 	validate := func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte("bench"))
 		h := fnv.New32a()

--- a/db_whitebox_test.go
+++ b/db_whitebox_test.go
@@ -42,7 +42,7 @@ func TestOpenWithPreLoadFreelist(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			db, err := Open(fileName, 0666, &Options{
+			db, err := Open(fileName, 0o666, &Options{
 				ReadOnly:        tc.readonly,
 				PreLoadFreelist: tc.preLoadFreePage,
 			})
@@ -88,7 +88,7 @@ func TestMethodPage(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			db, err := Open(fileName, 0666, &Options{
+			db, err := Open(fileName, 0o666, &Options{
 				ReadOnly:        tc.readonly,
 				PreLoadFreelist: tc.preLoadFreePage,
 			})
@@ -114,7 +114,7 @@ func TestMethodPage(t *testing.T) {
 
 func prepareData(t *testing.T) (string, error) {
 	fileName := filepath.Join(t.TempDir(), "db")
-	db, err := Open(fileName, 0666, nil)
+	db, err := Open(fileName, 0o666, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/btesting/btesting.go
+++ b/internal/btesting/btesting.go
@@ -63,7 +63,7 @@ func OpenDBWithOption(t testing.TB, f string, o *bolt.Options) (*DB, error) {
 
 	o.FreelistType = freelistType
 
-	db, err := bolt.Open(f, 0600, o)
+	db, err := bolt.Open(f, 0o600, o)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (db *DB) MustReopen() {
 		panic("Please call Close() before MustReopen()")
 	}
 	db.t.Logf("Reopening bbolt DB at: %s", db.f)
-	indb, err := bolt.Open(db.Path(), 0600, db.o)
+	indb, err := bolt.Open(db.Path(), 0o600, db.o)
 	require.NoError(db.t, err)
 	db.DB = indb
 	db.strictModeEnabledDefault()
@@ -144,8 +144,8 @@ func (db *DB) MustCheck() {
 
 		// If errors occurred, copy the DB and print the errors.
 		if len(errors) > 0 {
-			var path = filepath.Join(db.t.TempDir(), "db.backup")
-			err := tx.CopyFile(path, 0600)
+			path := filepath.Join(db.t.TempDir(), "db.backup")
+			err := tx.CopyFile(path, 0o600)
 			require.NoError(db.t, err)
 
 			// Print errors.
@@ -169,7 +169,8 @@ func (db *DB) MustCheck() {
 // Fill - fills the DB using numTx transactions and numKeysPerTx.
 func (db *DB) Fill(bucket []byte, numTx int, numKeysPerTx int,
 	keyGen func(tx int, key int) []byte,
-	valueGen func(tx int, key int) []byte) error {
+	valueGen func(tx int, key int) []byte,
+) error {
 	for tr := 0; tr < numTx; tr++ {
 		err := db.Update(func(tx *bolt.Tx) error {
 			b, _ := tx.CreateBucketIfNotExists(bucket)
@@ -195,7 +196,7 @@ func (db *DB) Path() string {
 func (db *DB) CopyTempFile() {
 	path := filepath.Join(db.t.TempDir(), "db.copy")
 	err := db.View(func(tx *bolt.Tx) error {
-		return tx.CopyFile(path, 0600)
+		return tx.CopyFile(path, 0o600)
 	})
 	require.NoError(db.t, err)
 	fmt.Println("db copied to: ", path)
@@ -203,7 +204,7 @@ func (db *DB) CopyTempFile() {
 
 // PrintStats prints the database stats
 func (db *DB) PrintStats() {
-	var stats = db.Stats()
+	stats := db.Stats()
 	fmt.Printf("[db] %-20s %-20s %-20s\n",
 		fmt.Sprintf("pg(%d/%d)", stats.TxStats.GetPageCount(), stats.TxStats.GetPageAlloc()),
 		fmt.Sprintf("cur(%d)", stats.TxStats.GetCursorCount()),

--- a/internal/common/meta.go
+++ b/internal/common/meta.go
@@ -59,7 +59,7 @@ func (m *Meta) Write(p *Page) {
 
 // Sum64 generates the checksum for the meta.
 func (m *Meta) Sum64() uint64 {
-	var h = fnv.New64a()
+	h := fnv.New64a()
 	_, _ = h.Write((*[unsafe.Offsetof(Meta{}.checksum)]byte)(unsafe.Pointer(m))[:])
 	return h.Sum64()
 }

--- a/internal/common/page.go
+++ b/internal/common/page.go
@@ -11,9 +11,11 @@ const PageHeaderSize = unsafe.Sizeof(Page{})
 
 const MinKeysPerPage = 2
 
-const BranchPageElementSize = unsafe.Sizeof(branchPageElement{})
-const LeafPageElementSize = unsafe.Sizeof(leafPageElement{})
-const pgidSize = unsafe.Sizeof(Pgid(0))
+const (
+	BranchPageElementSize = unsafe.Sizeof(branchPageElement{})
+	LeafPageElementSize   = unsafe.Sizeof(leafPageElement{})
+	pgidSize              = unsafe.Sizeof(Pgid(0))
+)
 
 const (
 	BranchPageFlag   = 0x01
@@ -126,7 +128,7 @@ func (p *Page) FreelistPageCount() (int, int) {
 
 	// If the page.count is at the max uint16 value (64k) then it's considered
 	// an overflow and the size of the freelist is stored as the first element.
-	var idx, count = 0, int(p.count)
+	idx, count := 0, int(p.count)
 	if count == 0xFFFF {
 		idx = 1
 		c := *(*Pgid)(UnsafeAdd(unsafe.Pointer(p), unsafe.Sizeof(*p)))

--- a/internal/freelist/freelist_test.go
+++ b/internal/freelist/freelist_test.go
@@ -118,7 +118,7 @@ func TestFreelist_releaseRange(t *testing.T) {
 		freeTxn  common.Txid
 	}
 
-	var releaseRangeTests = []struct {
+	releaseRangeTests := []struct {
 		title         string
 		pagesIn       []testPage
 		releaseRanges []testRange
@@ -609,7 +609,6 @@ func Test_freelist_ReadIDs_and_getFreePageIDs(t *testing.T) {
 	if got2 := f2.freePageIds(); !reflect.DeepEqual(got2, common.Pgids(exp2)) {
 		t.Fatalf("exp2=%#v; got2=%#v", exp2, got2)
 	}
-
 }
 
 // newTestFreelist get the freelist type from env and initial the freelist

--- a/internal/freelist/hashmap.go
+++ b/internal/freelist/hashmap.go
@@ -213,7 +213,7 @@ func (f *hashMap) mergeWithExistingSpan(pid common.Pgid) {
 	newSize := uint64(1)
 
 	if mergeWithPrev {
-		//merge with previous span
+		// merge with previous span
 		start := prev + 1 - common.Pgid(preSize)
 		f.delSpan(start, preSize)
 

--- a/internal/guts_cli/guts_cli.go
+++ b/internal/guts_cli/guts_cli.go
@@ -11,10 +11,8 @@ import (
 	"go.etcd.io/bbolt/internal/common"
 )
 
-var (
-	// ErrCorrupt is returned when a checking a data file finds errors.
-	ErrCorrupt = errors.New("invalid value")
-)
+// ErrCorrupt is returned when a checking a data file finds errors.
+var ErrCorrupt = errors.New("invalid value")
 
 // ReadPage reads Page info & full Page data from a path.
 // This is not transactionally safe.

--- a/internal/surgeon/surgeon.go
+++ b/internal/surgeon/surgeon.go
@@ -68,9 +68,7 @@ func ClearPageElements(path string, pgId common.Pgid, start, end int, abandonFre
 
 	preOverflow := p.Overflow()
 
-	var (
-		dataWritten uint32
-	)
+	var dataWritten uint32
 	if end == int(p.Count()) || end == -1 {
 		inodes := common.ReadInodeFromPage(p)
 		inodes = inodes[:start]

--- a/logger.go
+++ b/logger.go
@@ -32,9 +32,7 @@ func getDiscardLogger() Logger {
 	return discardLogger
 }
 
-var (
-	discardLogger = &DefaultLogger{Logger: log.New(io.Discard, "", 0)}
-)
+var discardLogger = &DefaultLogger{Logger: log.New(io.Discard, "", 0)}
 
 const (
 	calldepth = 2

--- a/manydbs_test.go
+++ b/manydbs_test.go
@@ -17,7 +17,7 @@ func createDb(t *testing.T) (*DB, func()) {
 	}
 	path := filepath.Join(tempDirName, "testdb.db")
 
-	bdb, err := Open(path, 0600, nil)
+	bdb, err := Open(path, 0o600, nil)
 	if err != nil {
 		t.Fatalf("error creating bbolt db: %v", err)
 	}

--- a/movebucket_test.go
+++ b/movebucket_test.go
@@ -141,7 +141,6 @@ func TestTx_MoveBucket(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		t.Run(tc.name, func(*testing.T) {
 			db := btesting.MustCreateDBWithOption(t, &bbolt.Options{PageSize: 4096})
 
@@ -376,7 +375,7 @@ func createBucketAndPopulateData(t testing.TB, tx *bbolt.Tx, bk *bbolt.Bucket, b
 }
 
 func populateSampleDataInBucket(t testing.TB, bk *bbolt.Bucket, n int) {
-	var min, max = 1, 1024
+	min, max := 1, 1024
 
 	for i := 0; i < n; i++ {
 		// generate rand key/value length

--- a/node.go
+++ b/node.go
@@ -234,7 +234,7 @@ func (n *node) splitTwo(pageSize uintptr) (*node, *node) {
 	}
 
 	// Determine the threshold before starting a new node.
-	var fillPercent = n.bucket.FillPercent
+	fillPercent := n.bucket.FillPercent
 	if fillPercent < minFillPercent {
 		fillPercent = minFillPercent
 	} else if fillPercent > maxFillPercent {
@@ -293,7 +293,7 @@ func (n *node) splitIndex(threshold int) (index, sz uintptr) {
 // spill writes the nodes to dirty pages and splits nodes as it goes.
 // Returns an error if dirty pages cannot be allocated.
 func (n *node) spill() error {
-	var tx = n.bucket.tx
+	tx := n.bucket.tx
 	if n.spilled {
 		return nil
 	}
@@ -312,7 +312,7 @@ func (n *node) spill() error {
 	n.children = nil
 
 	// Split nodes into appropriate sizes. The first node will always be n.
-	var nodes = n.split(uintptr(tx.db.pageSize))
+	nodes := n.split(uintptr(tx.db.pageSize))
 	for _, node := range nodes {
 		// Add node's page to the freelist if it's not new.
 		if node.pgid > 0 {
@@ -336,7 +336,7 @@ func (n *node) spill() error {
 
 		// Insert into parent inodes.
 		if node.parent != nil {
-			var key = node.key
+			key := node.key
 			if key == nil {
 				key = node.inodes[0].Key()
 			}
@@ -372,7 +372,7 @@ func (n *node) rebalance() {
 	n.bucket.tx.stats.IncRebalance(1)
 
 	// Ignore if node is above threshold (25% when FillPercent is set to DefaultFillPercent) and has enough keys.
-	var threshold = int(float64(n.bucket.tx.db.pageSize)*n.bucket.FillPercent) / 2
+	threshold := int(float64(n.bucket.tx.db.pageSize)*n.bucket.FillPercent) / 2
 	if n.size() > threshold && len(n.inodes) > n.minKeys() {
 		return
 	}
@@ -417,7 +417,7 @@ func (n *node) rebalance() {
 
 	// Merge with right sibling if idx == 0, otherwise left sibling.
 	var leftNode, rightNode *node
-	var useNextSibling = n.parent.childIndex(n) == 0
+	useNextSibling := n.parent.childIndex(n) == 0
 	if useNextSibling {
 		leftNode = n
 		rightNode = n.nextSibling()

--- a/node_test.go
+++ b/node_test.go
@@ -44,7 +44,7 @@ func TestNode_read_LeafPage(t *testing.T) {
 
 	// Insert 2 elements at the beginning. sizeof(leafPageElement) == 16
 	nodes := page.LeafPageElements()
-	//nodes := (*[3]leafPageElement)(unsafe.Pointer(uintptr(unsafe.Pointer(page)) + unsafe.Sizeof(*page)))
+	// nodes := (*[3]leafPageElement)(unsafe.Pointer(uintptr(unsafe.Pointer(page)) + unsafe.Sizeof(*page)))
 	nodes[0] = *common.NewLeafPageElement(0, 32, 3, 4)  // pos = sizeof(leafPageElement) * 2
 	nodes[1] = *common.NewLeafPageElement(0, 23, 10, 3) // pos = sizeof(leafPageElement) + 3 + 4
 
@@ -121,7 +121,7 @@ func TestNode_split(t *testing.T) {
 	// Split between 2 & 3.
 	n.split(100)
 
-	var parent = n.parent
+	parent := n.parent
 	if len(parent.children) != 2 {
 		t.Fatalf("exp=2; got=%d", len(parent.children))
 	}

--- a/simulation_no_freelist_sync_test.go
+++ b/simulation_no_freelist_sync_test.go
@@ -9,39 +9,51 @@ import (
 func TestSimulateNoFreeListSync_1op_1p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1, 1)
 }
+
 func TestSimulateNoFreeListSync_10op_1p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10, 1)
 }
+
 func TestSimulateNoFreeListSync_100op_1p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 100, 1)
 }
+
 func TestSimulateNoFreeListSync_1000op_1p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1000, 1)
 }
+
 func TestSimulateNoFreeListSync_10000op_1p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 1)
 }
+
 func TestSimulateNoFreeListSync_10op_10p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10, 10)
 }
+
 func TestSimulateNoFreeListSync_100op_10p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 100, 10)
 }
+
 func TestSimulateNoFreeListSync_1000op_10p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1000, 10)
 }
+
 func TestSimulateNoFreeListSync_10000op_10p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 10)
 }
+
 func TestSimulateNoFreeListSync_100op_100p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 100, 100)
 }
+
 func TestSimulateNoFreeListSync_1000op_100p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 1000, 100)
 }
+
 func TestSimulateNoFreeListSync_10000op_100p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 100)
 }
+
 func TestSimulateNoFreeListSync_10000op_1000p(t *testing.T) {
 	testSimulate(t, &bolt.Options{NoFreelistSync: true}, 8, 10000, 1000)
 }

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -36,10 +36,10 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 	}
 
 	// A list of operations that readers and writers can perform.
-	var readerHandlers = []simulateHandler{simulateGetHandler}
-	var writerHandlers = []simulateHandler{simulateGetHandler, simulatePutHandler}
+	readerHandlers := []simulateHandler{simulateGetHandler}
+	writerHandlers := []simulateHandler{simulateGetHandler, simulatePutHandler}
 
-	var versions = make(map[int]*QuickDB)
+	versions := make(map[int]*QuickDB)
 	versions[1] = NewQuickDB()
 
 	db := btesting.MustCreateDBWithOption(t, openOption)
@@ -48,7 +48,7 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 
 	for n := 0; n < round; n++ {
 		// Run n threads in parallel, each with their own operation.
-		var threads = make(chan bool, parallelism)
+		threads := make(chan bool, parallelism)
 		var wg sync.WaitGroup
 
 		// counter for how many goroutines were fired
@@ -57,7 +57,7 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 		// counter for ignored operations
 		var igCount int64
 
-		var errCh = make(chan error, threadCount)
+		errCh := make(chan error, threadCount)
 
 		var i int
 		for {
@@ -92,7 +92,7 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 
 				// Obtain current state of the dataset.
 				mutex.Lock()
-				var qdb = versions[tx.ID()]
+				qdb := versions[tx.ID()]
 				if writable {
 					qdb = versions[tx.ID()-1].Copy()
 				}
@@ -149,7 +149,6 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 		db.MustDeleteFile()
 		db.MustReopen()
 	}
-
 }
 
 type simulateHandler func(tx *bolt.Tx, qdb *QuickDB)
@@ -334,7 +333,7 @@ func (db *QuickDB) copy(m map[string]interface{}) map[string]interface{} {
 }
 
 func randKey() []byte {
-	var min, max = 1, 1024
+	min, max := 1, 1024
 	n := rand.Intn(max-min) + min
 	b := make([]byte, n)
 	for i := 0; i < n; i++ {
@@ -345,7 +344,7 @@ func randKey() []byte {
 
 func randKeys() [][]byte {
 	var keys [][]byte
-	var count = rand.Intn(2) + 2
+	count := rand.Intn(2) + 2
 	for i := 0; i < count; i++ {
 		keys = append(keys, randKey())
 	}

--- a/tests/dmflakey/dmflakey.go
+++ b/tests/dmflakey/dmflakey.go
@@ -151,7 +151,7 @@ func (f *flakey) Filesystem() FSType {
 
 // AllowWrites allows write I/O.
 func (f *flakey) AllowWrites(opts ...FeatOpt) error {
-	var o = defaultFeatCfg
+	o := defaultFeatCfg
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -182,7 +182,7 @@ func (f *flakey) AllowWrites(opts ...FeatOpt) error {
 
 // DropWrites drops all write I/O silently.
 func (f *flakey) DropWrites(opts ...FeatOpt) error {
-	var o = defaultFeatCfg
+	o := defaultFeatCfg
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -224,7 +224,7 @@ func (f *flakey) DropWrites(opts ...FeatOpt) error {
 
 // ErrorWrites drops all write I/O and returns error.
 func (f *flakey) ErrorWrites(opts ...FeatOpt) error {
-	var o = defaultFeatCfg
+	o := defaultFeatCfg
 	for _, opt := range opts {
 		opt(&o)
 	}
@@ -307,7 +307,7 @@ func createEmptyFSImage(imgPath string, fsType FSType, mkfsOpt string) error {
 		return fmt.Errorf("failed to create image because %s already exists", imgPath)
 	}
 
-	if err := os.MkdirAll(path.Dir(imgPath), 0600); err != nil {
+	if err := os.MkdirAll(path.Dir(imgPath), 0o600); err != nil {
 		return fmt.Errorf("failed to ensure parent directory %s: %w", path.Dir(imgPath), err)
 	}
 

--- a/tests/dmflakey/dmflakey_test.go
+++ b/tests/dmflakey/dmflakey_test.go
@@ -37,7 +37,7 @@ func TestBasic(t *testing.T) {
 			}()
 
 			target := filepath.Join(tmpDir, "root")
-			require.NoError(t, os.MkdirAll(target, 0600))
+			require.NoError(t, os.MkdirAll(target, 0o600))
 
 			require.NoError(t, mount(target, flakey.DevicePath(), ""))
 			defer func() {
@@ -45,7 +45,7 @@ func TestBasic(t *testing.T) {
 			}()
 
 			file := filepath.Join(target, "test")
-			assert.NoError(t, writeFile(file, []byte("hello, world"), 0600, true))
+			assert.NoError(t, writeFile(file, []byte("hello, world"), 0o600, true))
 
 			assert.NoError(t, unmount(target))
 
@@ -62,15 +62,15 @@ func TestDropWritesExt4(t *testing.T) {
 
 	// ensure testdir/f1 is synced.
 	target := filepath.Join(root, "testdir")
-	require.NoError(t, os.MkdirAll(target, 0600))
+	require.NoError(t, os.MkdirAll(target, 0o600))
 
 	f1 := filepath.Join(target, "f1")
-	assert.NoError(t, writeFile(f1, []byte("hello, world from f1"), 0600, false))
+	assert.NoError(t, writeFile(f1, []byte("hello, world from f1"), 0o600, false))
 	require.NoError(t, syncfs(f1))
 
 	// testdir/f2 is created but without fsync
 	f2 := filepath.Join(target, "f2")
-	assert.NoError(t, writeFile(f2, []byte("hello, world from f2"), 0600, false))
+	assert.NoError(t, writeFile(f2, []byte("hello, world from f2"), 0o600, false))
 
 	// simulate power failure
 	assert.NoError(t, flakey.DropWrites())
@@ -96,12 +96,12 @@ func TestErrorWritesExt4(t *testing.T) {
 	assert.NoError(t, flakey.ErrorWrites())
 
 	f1 := filepath.Join(root, "f1")
-	err := writeFile(f1, []byte("hello, world during failpoint"), 0600, true)
+	err := writeFile(f1, []byte("hello, world during failpoint"), 0o600, true)
 	assert.ErrorContains(t, err, "input/output error")
 
 	// resume
 	assert.NoError(t, flakey.AllowWrites())
-	err = writeFile(f1, []byte("hello, world"), 0600, true)
+	err = writeFile(f1, []byte("hello, world"), 0o600, true)
 	assert.NoError(t, err)
 
 	assert.NoError(t, unmount(root))
@@ -116,7 +116,7 @@ func initFlakey(t *testing.T, fsType FSType) (_ Flakey, root string) {
 	tmpDir := t.TempDir()
 
 	target := filepath.Join(tmpDir, "root")
-	require.NoError(t, os.MkdirAll(target, 0600))
+	require.NoError(t, os.MkdirAll(target, 0o600))
 
 	flakey, err := InitFlakey("go-dmflakey", tmpDir, fsType, "")
 	require.NoError(t, err, "init flakey")

--- a/tests/failpoint/db_failpoint_test.go
+++ b/tests/failpoint/db_failpoint_test.go
@@ -26,28 +26,28 @@ func TestFailpoint_MapFail(t *testing.T) {
 	}()
 
 	f := filepath.Join(t.TempDir(), "db")
-	_, err = bolt.Open(f, 0600, nil)
+	_, err = bolt.Open(f, 0o600, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "map somehow failed")
 }
 
 // ensures when munmap fails, the flock is unlocked
 func TestFailpoint_UnmapFail_DbClose(t *testing.T) {
-	//unmap error on db close
-	//we need to open the db first, and then enable the error.
-	//otherwise the db cannot be opened.
+	// unmap error on db close
+	// we need to open the db first, and then enable the error.
+	// otherwise the db cannot be opened.
 	f := filepath.Join(t.TempDir(), "db")
 
 	err := gofail.Enable("unmapError", `return("unmap somehow failed")`)
 	require.NoError(t, err)
-	_, err = bolt.Open(f, 0600, nil)
+	_, err = bolt.Open(f, 0o600, nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "unmap somehow failed")
-	//disable the error, and try to reopen the db
+	// disable the error, and try to reopen the db
 	err = gofail.Disable("unmapError")
 	require.NoError(t, err)
 
-	db, err := bolt.Open(f, 0600, &bolt.Options{Timeout: 30 * time.Second})
+	db, err := bolt.Open(f, 0o600, &bolt.Options{Timeout: 30 * time.Second})
 	require.NoError(t, err)
 	err = db.Close()
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestFailpoint_mLockFail(t *testing.T) {
 	require.NoError(t, err)
 
 	f := filepath.Join(t.TempDir(), "db")
-	_, err = bolt.Open(f, 0600, &bolt.Options{Mlock: true})
+	_, err = bolt.Open(f, 0o600, &bolt.Options{Mlock: true})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "mlock somehow failed")
 
@@ -66,7 +66,7 @@ func TestFailpoint_mLockFail(t *testing.T) {
 	err = gofail.Disable("mlockError")
 	require.NoError(t, err)
 
-	_, err = bolt.Open(f, 0600, &bolt.Options{Mlock: true})
+	_, err = bolt.Open(f, 0o600, &bolt.Options{Mlock: true})
 	require.NoError(t, err)
 }
 

--- a/tests/robustness/powerfailure_test.go
+++ b/tests/robustness/powerfailure_test.go
@@ -145,7 +145,8 @@ func doPowerFailure(t *testing.T, du time.Duration, fsType dmflakey.FSType, mkfs
 
 	dbPath := filepath.Join(root, "boltdb")
 
-	args := []string{"bbolt", "bench",
+	args := []string{
+		"bbolt", "bench",
 		"-work", // keep the database
 		"-path", dbPath,
 		"-count=1000000000",
@@ -154,7 +155,7 @@ func doPowerFailure(t *testing.T, du time.Duration, fsType dmflakey.FSType, mkfs
 	}
 
 	logPath := filepath.Join(t.TempDir(), fmt.Sprintf("%s.log", t.Name()))
-	require.NoError(t, os.MkdirAll(path.Dir(logPath), 0600))
+	require.NoError(t, os.MkdirAll(path.Dir(logPath), 0o600))
 
 	logFd, err := os.Create(logPath)
 	require.NoError(t, err)

--- a/tx.go
+++ b/tx.go
@@ -191,7 +191,7 @@ func (tx *Tx) Commit() (err error) {
 	// TODO(benbjohnson): Use vectorized I/O to write out dirty pages.
 
 	// Rebalance nodes which have had deletions.
-	var startTime = time.Now()
+	startTime := time.Now()
 	tx.root.rebalance()
 	if tx.stats.GetRebalance() > 0 {
 		tx.stats.IncRebalanceTime(time.Since(startTime))
@@ -348,9 +348,9 @@ func (tx *Tx) close() {
 	}
 	if tx.writable {
 		// Grab freelist stats.
-		var freelistFreeN = tx.db.freelist.FreeCount()
-		var freelistPendingN = tx.db.freelist.PendingCount()
-		var freelistAlloc = tx.db.freelist.EstimatedWritePageSize()
+		freelistFreeN := tx.db.freelist.FreeCount()
+		freelistPendingN := tx.db.freelist.PendingCount()
+		freelistAlloc := tx.db.freelist.EstimatedWritePageSize()
 
 		// Remove transaction ref & writer lock.
 		tx.db.rwtx = nil

--- a/tx_check.go
+++ b/tx_check.go
@@ -84,13 +84,15 @@ func (tx *Tx) check(cfg checkConfig, ch chan error) {
 }
 
 func (tx *Tx) recursivelyCheckPage(pageId common.Pgid, reachable map[common.Pgid]*common.Page, freed map[common.Pgid]bool,
-	kvStringer KVStringer, ch chan error) {
+	kvStringer KVStringer, ch chan error,
+) {
 	tx.checkInvariantProperties(pageId, reachable, freed, kvStringer, ch)
 	tx.recursivelyCheckBucketInPage(pageId, reachable, freed, kvStringer, ch)
 }
 
 func (tx *Tx) recursivelyCheckBucketInPage(pageId common.Pgid, reachable map[common.Pgid]*common.Page, freed map[common.Pgid]bool,
-	kvStringer KVStringer, ch chan error) {
+	kvStringer KVStringer, ch chan error,
+) {
 	p := tx.page(pageId)
 
 	switch {
@@ -121,7 +123,8 @@ func (tx *Tx) recursivelyCheckBucketInPage(pageId common.Pgid, reachable map[com
 }
 
 func (tx *Tx) recursivelyCheckBucket(b *Bucket, reachable map[common.Pgid]*common.Page, freed map[common.Pgid]bool,
-	kvStringer KVStringer, ch chan error) {
+	kvStringer KVStringer, ch chan error,
+) {
 	// Ignore inline buckets.
 	if b.RootPage() == 0 {
 		return
@@ -139,7 +142,8 @@ func (tx *Tx) recursivelyCheckBucket(b *Bucket, reachable map[common.Pgid]*commo
 }
 
 func (tx *Tx) checkInvariantProperties(pageId common.Pgid, reachable map[common.Pgid]*common.Page, freed map[common.Pgid]bool,
-	kvStringer KVStringer, ch chan error) {
+	kvStringer KVStringer, ch chan error,
+) {
 	tx.forEachPage(pageId, func(p *common.Page, _ int, stack []common.Pgid) {
 		verifyPageReachable(p, tx.meta.Pgid(), stack, reachable, freed, ch)
 	})
@@ -154,7 +158,7 @@ func verifyPageReachable(p *common.Page, hwm common.Pgid, stack []common.Pgid, r
 
 	// Ensure each page is only referenced once.
 	for i := common.Pgid(0); i <= common.Pgid(p.Overflow()); i++ {
-		var id = p.Id() + i
+		id := p.Id() + i
 		if _, ok := reachable[id]; ok {
 			ch <- fmt.Errorf("page %d: multiple references (stack: %v)", int(id), stack)
 		}
@@ -184,8 +188,8 @@ func (tx *Tx) recursivelyCheckPageKeyOrder(pgId common.Pgid, keyToString func([]
 //     `pagesStack` is expected to contain IDs of pages from the tree root to `pgid` for the clean debugging message.
 func (tx *Tx) recursivelyCheckPageKeyOrderInternal(
 	pgId common.Pgid, minKeyClosed, maxKeyOpen []byte, pagesStack []common.Pgid,
-	keyToString func([]byte) string, ch chan error) (maxKeyInSubtree []byte) {
-
+	keyToString func([]byte) string, ch chan error,
+) (maxKeyInSubtree []byte) {
 	p := tx.page(pgId)
 	pagesStack = append(pagesStack, pgId)
 	switch {

--- a/tx_test.go
+++ b/tx_test.go
@@ -37,7 +37,7 @@ func TestTx_Check_ReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	readOnlyDB, err := bolt.Open(db.Path(), 0600, &bolt.Options{ReadOnly: true})
+	readOnlyDB, err := bolt.Open(db.Path(), 0o600, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -541,12 +541,12 @@ func TestTx_CopyFile(t *testing.T) {
 	}
 
 	if err := db.View(func(tx *bolt.Tx) error {
-		return tx.CopyFile(path, 0600)
+		return tx.CopyFile(path, 0o600)
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	db2, err := bolt.Open(path, 0600, nil)
+	db2, err := bolt.Open(path, 0o600, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -645,7 +645,7 @@ func TestTx_CopyFile_Error_Normal(t *testing.T) {
 func TestTx_Rollback(t *testing.T) {
 	for _, isSyncFreelist := range []bool{false, true} {
 		// Open the database.
-		db, err := bolt.Open(tempfile(), 0600, nil)
+		db, err := bolt.Open(tempfile(), 0o600, nil)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -688,7 +688,6 @@ func TestTx_Rollback(t *testing.T) {
 		if err := tx.Rollback(); err != nil {
 			t.Fatalf("Error on rollback: %v", err)
 		}
-
 	}
 }
 
@@ -798,7 +797,7 @@ func TestTx_releaseRange(t *testing.T) {
 
 func ExampleTx_Rollback() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -852,7 +851,7 @@ func ExampleTx_Rollback() {
 
 func ExampleTx_CopyFile() {
 	// Open the database.
-	db, err := bolt.Open(tempfile(), 0600, nil)
+	db, err := bolt.Open(tempfile(), 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -875,14 +874,14 @@ func ExampleTx_CopyFile() {
 	// Copy the database to another file.
 	toFile := tempfile()
 	if err := db.View(func(tx *bolt.Tx) error {
-		return tx.CopyFile(toFile, 0666)
+		return tx.CopyFile(toFile, 0o666)
 	}); err != nil {
 		log.Fatal(err)
 	}
 	defer os.Remove(toFile)
 
 	// Open the cloned database.
-	db2, err := bolt.Open(toFile, 0600, nil)
+	db2, err := bolt.Open(toFile, 0o600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/unix_test.go
+++ b/unix_test.go
@@ -42,7 +42,6 @@ func TestMlock_DbCanGrow_Small(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-
 }
 
 // Test crossing of 16MB (AllocSize) of db size

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,7 +12,7 @@ func dumpBucket(srcBucketName []byte, srcBucket *bolt.Bucket, dstFilename string
 	common.Assert(srcBucket != nil, "the source bucket can't be nil")
 	common.Assert(len(dstFilename) != 0, "the target file path can't be empty")
 
-	dstDB, err := bolt.Open(dstFilename, 0600, nil)
+	dstDB, err := bolt.Open(dstFilename, 0o600, nil)
 	if err != nil {
 		return err
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,4 @@
 package version
 
-var (
-	// Version shows the last bbolt binary version released.
-	Version = "1.4.0-alpha.0"
-)
+// Version shows the last bbolt binary version released.
+var Version = "1.4.0-alpha.0"


### PR DESCRIPTION
#### Description

This enable gofumpt, nakedret and revive.
There are only gofumpt related modification since the rest is already conform with nakedret and revive rules