### PR TITLE
chore: enable testifylint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - govet
     - ineffassign
     - staticcheck
+    - testifylint
     - unused
   exclusions:
     presets:
@@ -36,4 +37,10 @@ linters:
         - -ST1012 # Poorly chosen name for error variable
         - -ST1016 # Use consistent method receiver names
         - -ST1023 # Redundant type in variable declaration
+    testifylint:
+      disable:
+        - go-require
+      enable-all: true
+      formatter:
+        require-f-funcs: true
 version: "2"

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -3,6 +3,9 @@ package bbolt
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.etcd.io/bbolt/internal/common"
 	"go.etcd.io/bbolt/internal/freelist"
 )
@@ -26,14 +29,11 @@ func TestTx_allocatePageStats(t *testing.T) {
 			prePageCnt := txStats.GetPageCount()
 			allocateCnt := f.FreeCount()
 
-			if _, err := tx.allocate(allocateCnt); err != nil {
-				t.Fatal(err)
-			}
+			_, err := tx.allocate(allocateCnt)
+			require.NoError(t, err)
 
 			txStats = tx.Stats()
-			if txStats.GetPageCount() != prePageCnt+int64(allocateCnt) {
-				t.Errorf("Allocated %d but got %d page in stats", allocateCnt, txStats.GetPageCount())
-			}
+			assert.Equalf(t, txStats.GetPageCount(), prePageCnt+int64(allocateCnt), "Allocated %d but got %d page in stats", allocateCnt, txStats.GetPageCount())
 		})
 	}
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"testing/quick"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	bolt "go.etcd.io/bbolt"
@@ -152,88 +153,63 @@ func testRepeatCursorOperations_PrevNextPrev(t *testing.T, b *bolt.Bucket) {
 // Ensure that a cursor can return a reference to the bucket that created it.
 func TestCursor_Bucket(t *testing.T) {
 	db := btesting.MustCreateDB(t)
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if cb := b.Cursor().Bucket(); !reflect.DeepEqual(cb, b) {
-			t.Fatal("cursor bucket mismatch")
-		}
+		require.NoError(t, err)
+		cb := b.Cursor().Bucket()
+		require.Truef(t, reflect.DeepEqual(cb, b), "cursor bucket mismatch")
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a Tx cursor can seek to the appropriate keys.
 func TestCursor_Seek(t *testing.T) {
 	db := btesting.MustCreateDB(t)
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("foo"), []byte("0001")); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("bar"), []byte("0002")); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("baz"), []byte("0003")); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, b.Put([]byte("foo"), []byte("0001")))
+		require.NoError(t, b.Put([]byte("bar"), []byte("0002")))
+		require.NoError(t, b.Put([]byte("baz"), []byte("0003")))
 
-		if _, err := b.CreateBucket([]byte("bkt")); err != nil {
-			t.Fatal(err)
-		}
+		_, err = b.CreateBucket([]byte("bkt"))
+		require.NoError(t, err)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
-	if err := db.View(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket([]byte("widgets")).Cursor()
 
 		// Exact match should go to the key.
-		if k, v := c.Seek([]byte("bar")); !bytes.Equal(k, []byte("bar")) {
-			t.Fatalf("unexpected key: %v", k)
-		} else if !bytes.Equal(v, []byte("0002")) {
-			t.Fatalf("unexpected value: %v", v)
-		}
+		k, v := c.Seek([]byte("bar"))
+		require.Truef(t, bytes.Equal(k, []byte("bar")), "unexpected key: %v", k)
+		require.Truef(t, bytes.Equal(v, []byte("0002")), "unexpected value: %v", v)
 
 		// Inexact match should go to the next key.
-		if k, v := c.Seek([]byte("bas")); !bytes.Equal(k, []byte("baz")) {
-			t.Fatalf("unexpected key: %v", k)
-		} else if !bytes.Equal(v, []byte("0003")) {
-			t.Fatalf("unexpected value: %v", v)
-		}
+		k, v = c.Seek([]byte("bas"))
+		require.Truef(t, bytes.Equal(k, []byte("baz")), "unexpected key: %v", k)
+		require.Truef(t, bytes.Equal(v, []byte("0003")), "unexpected value: %v", v)
 
 		// Low key should go to the first key.
-		if k, v := c.Seek([]byte("")); !bytes.Equal(k, []byte("bar")) {
-			t.Fatalf("unexpected key: %v", k)
-		} else if !bytes.Equal(v, []byte("0002")) {
-			t.Fatalf("unexpected value: %v", v)
-		}
+		k, v = c.Seek([]byte(""))
+		require.Truef(t, bytes.Equal(k, []byte("bar")), "unexpected key: %v", k)
+		require.Truef(t, bytes.Equal(v, []byte("0002")), "unexpected value: %v", v)
 
 		// High key should return no key.
-		if k, v := c.Seek([]byte("zzz")); k != nil {
-			t.Fatalf("expected nil key: %v", k)
-		} else if v != nil {
-			t.Fatalf("expected nil value: %v", v)
-		}
+		k, v = c.Seek([]byte("zzz"))
+		require.Nilf(t, k, "expected nil key: %v", k)
+		require.Nilf(t, v, "expected nil value: %v", v)
 
 		// Buckets should return their key but no value.
-		if k, v := c.Seek([]byte("bkt")); !bytes.Equal(k, []byte("bkt")) {
-			t.Fatalf("unexpected key: %v", k)
-		} else if v != nil {
-			t.Fatalf("expected nil value: %v", v)
-		}
+		k, v = c.Seek([]byte("bkt"))
+		require.Truef(t, bytes.Equal(k, []byte("bkt")), "unexpected key: %v", k)
+		require.Nilf(t, v, "expected nil value: %v", v)
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 func TestCursor_Delete(t *testing.T) {
@@ -242,55 +218,41 @@ func TestCursor_Delete(t *testing.T) {
 	const count = 1000
 
 	// Insert every other key between 0 and $count.
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		for i := 0; i < count; i += 1 {
 			k := make([]byte, 8)
 			binary.BigEndian.PutUint64(k, uint64(i))
-			if err := b.Put(k, make([]byte, 100)); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Put(k, make([]byte, 100)))
 		}
-		if _, err := b.CreateBucket([]byte("sub")); err != nil {
-			t.Fatal(err)
-		}
+		_, err = b.CreateBucket([]byte("sub"))
+		require.NoError(t, err)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err = db.Update(func(tx *bolt.Tx) error {
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		bound := make([]byte, 8)
 		binary.BigEndian.PutUint64(bound, uint64(count/2))
 		for key, _ := c.First(); bytes.Compare(key, bound) < 0; key, _ = c.Next() {
-			if err := c.Delete(); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, c.Delete())
 		}
 
 		c.Seek([]byte("sub"))
-		if err := c.Delete(); err != errors.ErrIncompatibleValue {
-			t.Fatalf("unexpected error: %s", err)
-		}
+		require.Equalf(t, c.Delete(), errors.ErrIncompatibleValue, "unexpected error")
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
-	if err := db.View(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		stats := tx.Bucket([]byte("widgets")).Stats()
-		if stats.KeyN != count/2+1 {
-			t.Fatalf("unexpected KeyN: %d", stats.KeyN)
-		}
+		require.Equalf(t, count/2+1, stats.KeyN, "unexpected KeyN: %d", stats.KeyN)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a Tx cursor can seek to the appropriate keys when there are a
@@ -304,27 +266,22 @@ func TestCursor_Seek_Large(t *testing.T) {
 	var count = 10000
 
 	// Insert every other key between 0 and $count.
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		for i := 0; i < count; i += 100 {
 			for j := i; j < i+100; j += 2 {
 				k := make([]byte, 8)
 				binary.BigEndian.PutUint64(k, uint64(j))
-				if err := b.Put(k, make([]byte, 100)); err != nil {
-					t.Fatal(err)
-				}
+				require.NoError(t, b.Put(k, make([]byte, 100)))
 			}
 		}
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
-	if err := db.View(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		for i := 0; i < count; i++ {
 			seek := make([]byte, 8)
@@ -335,255 +292,172 @@ func TestCursor_Seek_Large(t *testing.T) {
 			// The last seek is beyond the end of the range so
 			// it should return nil.
 			if i == count-1 {
-				if k != nil {
-					t.Fatal("expected nil key")
-				}
+				require.Nilf(t, k, "expected nil key")
 				continue
 			}
 
 			// Otherwise we should seek to the exact key or the next key.
 			num := binary.BigEndian.Uint64(k)
 			if i%2 == 0 {
-				if num != uint64(i) {
-					t.Fatalf("unexpected num: %d", num)
-				}
+				require.Equalf(t, num, uint64(i), "unexpected num: %d", num)
 			} else {
-				if num != uint64(i+1) {
-					t.Fatalf("unexpected num: %d", num)
-				}
+				require.Equalf(t, num, uint64(i+1), "unexpected num: %d", num)
 			}
 		}
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a cursor can iterate over an empty bucket without error.
 func TestCursor_EmptyBucket(t *testing.T) {
 	db := btesting.MustCreateDB(t)
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
-	if err := db.View(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		k, v := c.First()
-		if k != nil {
-			t.Fatalf("unexpected key: %v", k)
-		} else if v != nil {
-			t.Fatalf("unexpected value: %v", v)
-		}
+		require.Nilf(t, k, "unexpected key: %v", k)
+		require.Nilf(t, v, "unexpected value: %v", v)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a Tx cursor can reverse iterate over an empty bucket without error.
 func TestCursor_EmptyBucketReverse(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucket([]byte("widgets"))
 		return err
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.View(func(tx *bolt.Tx) error {
+	})
+	require.NoError(t, err)
+	err = db.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		k, v := c.Last()
-		if k != nil {
-			t.Fatalf("unexpected key: %v", k)
-		} else if v != nil {
-			t.Fatalf("unexpected value: %v", v)
-		}
+		require.Nilf(t, k, "unexpected key: %v", k)
+		require.Nilf(t, v, "unexpected value: %v", v)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a Tx cursor can iterate over a single root with a couple elements.
 func TestCursor_Iterate_Leaf(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("baz"), []byte{}); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("foo"), []byte{0}); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("bar"), []byte{1}); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, b.Put([]byte("baz"), []byte{}))
+		require.NoError(t, b.Put([]byte("foo"), []byte{0}))
+		require.NoError(t, b.Put([]byte("bar"), []byte{1}))
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 	tx, err := db.Begin(false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() { _ = tx.Rollback() }()
 
 	c := tx.Bucket([]byte("widgets")).Cursor()
 
 	k, v := c.First()
-	if !bytes.Equal(k, []byte("bar")) {
-		t.Fatalf("unexpected key: %v", k)
-	} else if !bytes.Equal(v, []byte{1}) {
-		t.Fatalf("unexpected value: %v", v)
-	}
+	require.Truef(t, bytes.Equal(k, []byte("bar")), "unexpected key: %v", k)
+	require.Truef(t, bytes.Equal(v, []byte{1}), "unexpected value: %v", v)
 
 	k, v = c.Next()
-	if !bytes.Equal(k, []byte("baz")) {
-		t.Fatalf("unexpected key: %v", k)
-	} else if !bytes.Equal(v, []byte{}) {
-		t.Fatalf("unexpected value: %v", v)
-	}
+	require.Truef(t, bytes.Equal(k, []byte("baz")), "unexpected key: %v", k)
+	require.Truef(t, bytes.Equal(v, []byte{}), "unexpected value: %v", v)
 
 	k, v = c.Next()
-	if !bytes.Equal(k, []byte("foo")) {
-		t.Fatalf("unexpected key: %v", k)
-	} else if !bytes.Equal(v, []byte{0}) {
-		t.Fatalf("unexpected value: %v", v)
-	}
+	require.Truef(t, bytes.Equal(k, []byte("foo")), "unexpected key: %v", k)
+	require.Truef(t, bytes.Equal(v, []byte{0}), "unexpected value: %v", v)
 
 	k, v = c.Next()
-	if k != nil {
-		t.Fatalf("expected nil key: %v", k)
-	} else if v != nil {
-		t.Fatalf("expected nil value: %v", v)
-	}
+	require.Nilf(t, k, "expected nil key: %v", k)
+	require.Nilf(t, v, "expected nil value: %v", v)
 
 	k, v = c.Next()
-	if k != nil {
-		t.Fatalf("expected nil key: %v", k)
-	} else if v != nil {
-		t.Fatalf("expected nil value: %v", v)
-	}
+	require.Nilf(t, k, "expected nil key: %v", k)
+	require.Nilf(t, v, "expected nil value: %v", v)
 
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, tx.Rollback())
 }
 
 // Ensure that a Tx cursor can iterate in reverse over a single root with a couple elements.
 func TestCursor_LeafRootReverse(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("baz"), []byte{}); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("foo"), []byte{0}); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("bar"), []byte{1}); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, b.Put([]byte("baz"), []byte{}))
+		require.NoError(t, b.Put([]byte("foo"), []byte{0}))
+		require.NoError(t, b.Put([]byte("bar"), []byte{1}))
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 	tx, err := db.Begin(false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	c := tx.Bucket([]byte("widgets")).Cursor()
 
-	if k, v := c.Last(); !bytes.Equal(k, []byte("foo")) {
-		t.Fatalf("unexpected key: %v", k)
-	} else if !bytes.Equal(v, []byte{0}) {
-		t.Fatalf("unexpected value: %v", v)
-	}
+	k, v := c.Last()
+	require.Truef(t, bytes.Equal(k, []byte("foo")), "unexpected key: %v", k)
+	require.Truef(t, bytes.Equal(v, []byte{0}), "unexpected value: %v", v)
 
-	if k, v := c.Prev(); !bytes.Equal(k, []byte("baz")) {
-		t.Fatalf("unexpected key: %v", k)
-	} else if !bytes.Equal(v, []byte{}) {
-		t.Fatalf("unexpected value: %v", v)
-	}
+	k, v = c.Prev()
+	require.Truef(t, bytes.Equal(k, []byte("baz")), "unexpected key: %v", k)
+	require.Truef(t, bytes.Equal(v, []byte{}), "unexpected value: %v", v)
 
-	if k, v := c.Prev(); !bytes.Equal(k, []byte("bar")) {
-		t.Fatalf("unexpected key: %v", k)
-	} else if !bytes.Equal(v, []byte{1}) {
-		t.Fatalf("unexpected value: %v", v)
-	}
+	k, v = c.Prev()
+	require.Truef(t, bytes.Equal(k, []byte("bar")), "unexpected key: %v", k)
+	require.Truef(t, bytes.Equal(v, []byte{1}), "unexpected value: %v", v)
 
-	if k, v := c.Prev(); k != nil {
-		t.Fatalf("expected nil key: %v", k)
-	} else if v != nil {
-		t.Fatalf("expected nil value: %v", v)
-	}
+	k, v = c.Prev()
+	require.Nilf(t, k, "expected nil key: %v", k)
+	require.Nilf(t, v, "expected nil value: %v", v)
 
-	if k, v := c.Prev(); k != nil {
-		t.Fatalf("expected nil key: %v", k)
-	} else if v != nil {
-		t.Fatalf("expected nil value: %v", v)
-	}
+	k, v = c.Prev()
+	require.Nilf(t, k, "expected nil key: %v", k)
+	require.Nilf(t, v, "expected nil value: %v", v)
 
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, tx.Rollback())
 }
 
 // Ensure that a Tx cursor can restart from the beginning.
 func TestCursor_Restart(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("bar"), []byte{}); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.Put([]byte("foo"), []byte{}); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, b.Put([]byte("bar"), []byte{}))
+		require.NoError(t, b.Put([]byte("foo"), []byte{}))
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
 	tx, err := db.Begin(false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	c := tx.Bucket([]byte("widgets")).Cursor()
 
-	if k, _ := c.First(); !bytes.Equal(k, []byte("bar")) {
-		t.Fatalf("unexpected key: %v", k)
-	}
-	if k, _ := c.Next(); !bytes.Equal(k, []byte("foo")) {
-		t.Fatalf("unexpected key: %v", k)
-	}
+	k, _ := c.First()
+	require.Truef(t, bytes.Equal(k, []byte("bar")), "unexpected key: %v", k)
+	k, _ = c.Next()
+	require.Truef(t, bytes.Equal(k, []byte("foo")), "unexpected key: %v", k)
 
-	if k, _ := c.First(); !bytes.Equal(k, []byte("bar")) {
-		t.Fatalf("unexpected key: %v", k)
-	}
-	if k, _ := c.Next(); !bytes.Equal(k, []byte("foo")) {
-		t.Fatalf("unexpected key: %v", k)
-	}
+	k, _ = c.First()
+	require.Truef(t, bytes.Equal(k, []byte("bar")), "unexpected key: %v", k)
+	k, _ = c.Next()
+	require.Truef(t, bytes.Equal(k, []byte("foo")), "unexpected key: %v", k)
 
-	if err := tx.Rollback(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, tx.Rollback())
 }
 
 // Ensure that a cursor can skip over empty pages that have been deleted.
@@ -591,30 +465,23 @@ func TestCursor_First_EmptyPages(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
 	// Create 1000 keys in the "widgets" bucket.
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		for i := 0; i < 1000; i++ {
-			if err := b.Put(u64tob(uint64(i)), []byte{}); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Put(u64tob(uint64(i)), []byte{}))
 		}
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
 	// Delete half the keys and then try to iterate.
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err = db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("widgets"))
 		for i := 0; i < 600; i++ {
-			if err := b.Delete(u64tob(uint64(i))); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Delete(u64tob(uint64(i))))
 		}
 
 		c := b.Cursor()
@@ -622,14 +489,11 @@ func TestCursor_First_EmptyPages(t *testing.T) {
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
 			n++
 		}
-		if n != 400 {
-			t.Fatalf("unexpected key count: %d", n)
-		}
+		require.Equalf(t, 400, n, "unexpected key count: %d", n)
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a cursor can skip over empty pages that have been deleted.
@@ -637,30 +501,23 @@ func TestCursor_Last_EmptyPages(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
 	// Create 1000 keys in the "widgets" bucket.
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		for i := 0; i < 1000; i++ {
-			if err := b.Put(u64tob(uint64(i)), []byte{}); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Put(u64tob(uint64(i)), []byte{}))
 		}
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
 	// Delete last 800 elements to ensure last page is empty
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err = db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte("widgets"))
 		for i := 200; i < 1000; i++ {
-			if err := b.Delete(u64tob(uint64(i))); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Delete(u64tob(uint64(i))))
 		}
 
 		c := b.Cursor()
@@ -668,14 +525,11 @@ func TestCursor_Last_EmptyPages(t *testing.T) {
 		for k, _ := c.Last(); k != nil; k, _ = c.Prev() {
 			n++
 		}
-		if n != 200 {
-			t.Fatalf("unexpected key count: %d", n)
-		}
+		require.Equalf(t, 200, n, "unexpected key count: %d", n)
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a Tx can iterate over all elements in a bucket.
@@ -686,21 +540,13 @@ func TestCursor_QuickCheck(t *testing.T) {
 
 		// Bulk insert all values.
 		tx, err := db.Begin(true)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		for _, item := range items {
-			if err := b.Put(item.Key, item.Value); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Put(item.Key, item.Value))
 		}
-		if err := tx.Commit(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, tx.Commit())
 
 		// Sort test data.
 		sort.Sort(items)
@@ -708,32 +554,21 @@ func TestCursor_QuickCheck(t *testing.T) {
 		// Iterate over all items and check consistency.
 		var index = 0
 		tx, err = db.Begin(false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		for k, v := c.First(); k != nil && index < len(items); k, v = c.Next() {
-			if !bytes.Equal(k, items[index].Key) {
-				t.Fatalf("unexpected key: %v", k)
-			} else if !bytes.Equal(v, items[index].Value) {
-				t.Fatalf("unexpected value: %v", v)
-			}
+			require.Truef(t, bytes.Equal(k, items[index].Key), "unexpected key: %v", k)
+			require.Truef(t, bytes.Equal(v, items[index].Value), "unexpected value: %v", v)
 			index++
 		}
-		if len(items) != index {
-			t.Fatalf("unexpected item count: %v, expected %v", len(items), index)
-		}
+		require.Equalf(t, len(items), index, "unexpected item count: %v, expected %v", len(items), index)
 
-		if err := tx.Rollback(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, tx.Rollback())
 
 		return true
 	}
-	if err := quick.Check(f, qconfig()); err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, quick.Check(f, qconfig()))
 }
 
 // Ensure that a transaction can iterate over all elements in a bucket in reverse.
@@ -744,21 +579,13 @@ func TestCursor_QuickCheck_Reverse(t *testing.T) {
 
 		// Bulk insert all values.
 		tx, err := db.Begin(true)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		for _, item := range items {
-			if err := b.Put(item.Key, item.Value); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Put(item.Key, item.Value))
 		}
-		if err := tx.Commit(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, tx.Commit())
 
 		// Sort test data.
 		sort.Sort(revtestdata(items))
@@ -766,113 +593,80 @@ func TestCursor_QuickCheck_Reverse(t *testing.T) {
 		// Iterate over all items and check consistency.
 		var index = 0
 		tx, err = db.Begin(false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		for k, v := c.Last(); k != nil && index < len(items); k, v = c.Prev() {
-			if !bytes.Equal(k, items[index].Key) {
-				t.Fatalf("unexpected key: %v", k)
-			} else if !bytes.Equal(v, items[index].Value) {
-				t.Fatalf("unexpected value: %v", v)
-			}
+			require.Truef(t, bytes.Equal(k, items[index].Key), "unexpected key: %v", k)
+			require.Truef(t, bytes.Equal(v, items[index].Value), "unexpected value: %v", v)
 			index++
 		}
-		if len(items) != index {
-			t.Fatalf("unexpected item count: %v, expected %v", len(items), index)
-		}
+		require.Equalf(t, len(items), index, "unexpected item count: %v, expected %v", len(items), index)
 
-		if err := tx.Rollback(); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, tx.Rollback())
 
 		return true
 	}
-	if err := quick.Check(f, qconfig()); err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, quick.Check(f, qconfig()))
 }
 
 // Ensure that a Tx cursor can iterate over subbuckets.
 func TestCursor_QuickCheck_BucketsOnly(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := b.CreateBucket([]byte("foo")); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := b.CreateBucket([]byte("bar")); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := b.CreateBucket([]byte("baz")); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		_, err = b.CreateBucket([]byte("foo"))
+		require.NoError(t, err)
+		_, err = b.CreateBucket([]byte("bar"))
+		require.NoError(t, err)
+		_, err = b.CreateBucket([]byte("baz"))
+		require.NoError(t, err)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
-	if err := db.View(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		var names []string
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			names = append(names, string(k))
-			if v != nil {
-				t.Fatalf("unexpected value: %v", v)
-			}
+			require.Nilf(t, v, "unexpected value: %v", v)
 		}
-		if !reflect.DeepEqual(names, []string{"bar", "baz", "foo"}) {
-			t.Fatalf("unexpected names: %+v", names)
-		}
+		require.Truef(t, reflect.DeepEqual(names, []string{"bar", "baz", "foo"}), "unexpected names: %+v", names)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Ensure that a Tx cursor can reverse iterate over subbuckets.
 func TestCursor_QuickCheck_BucketsOnly_Reverse(t *testing.T) {
 	db := btesting.MustCreateDB(t)
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucket([]byte("widgets"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := b.CreateBucket([]byte("foo")); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := b.CreateBucket([]byte("bar")); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := b.CreateBucket([]byte("baz")); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		_, err = b.CreateBucket([]byte("foo"))
+		require.NoError(t, err)
+		_, err = b.CreateBucket([]byte("bar"))
+		require.NoError(t, err)
+		_, err = b.CreateBucket([]byte("baz"))
+		require.NoError(t, err)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
-	if err := db.View(func(tx *bolt.Tx) error {
+	err = db.View(func(tx *bolt.Tx) error {
 		var names []string
 		c := tx.Bucket([]byte("widgets")).Cursor()
 		for k, v := c.Last(); k != nil; k, v = c.Prev() {
 			names = append(names, string(k))
-			if v != nil {
-				t.Fatalf("unexpected value: %v", v)
-			}
+			require.Nilf(t, v, "unexpected value: %v", v)
 		}
-		if !reflect.DeepEqual(names, []string{"foo", "baz", "bar"}) {
-			t.Fatalf("unexpected names: %+v", names)
-		}
+		require.Truef(t, reflect.DeepEqual(names, []string{"foo", "baz", "bar"}), "unexpected names: %+v", names)
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 func ExampleCursor() {

--- a/internal/btesting/btesting.go
+++ b/internal/btesting/btesting.go
@@ -105,8 +105,7 @@ func (db *DB) Close() error {
 
 // MustClose closes the database but does NOT delete the underlying file.
 func (db *DB) MustClose() {
-	err := db.Close()
-	require.NoError(db.t, err)
+	require.NoError(db.t, db.Close())
 }
 
 func (db *DB) MustDeleteFile() {

--- a/internal/common/page_test.go
+++ b/internal/common/page_test.go
@@ -5,25 +5,23 @@ import (
 	"sort"
 	"testing"
 	"testing/quick"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Ensure that the page type can be returned in human readable format.
 func TestPage_typ(t *testing.T) {
-	if typ := (&Page{flags: BranchPageFlag}).Typ(); typ != "branch" {
-		t.Fatalf("exp=branch; got=%v", typ)
-	}
-	if typ := (&Page{flags: LeafPageFlag}).Typ(); typ != "leaf" {
-		t.Fatalf("exp=leaf; got=%v", typ)
-	}
-	if typ := (&Page{flags: MetaPageFlag}).Typ(); typ != "meta" {
-		t.Fatalf("exp=meta; got=%v", typ)
-	}
-	if typ := (&Page{flags: FreelistPageFlag}).Typ(); typ != "freelist" {
-		t.Fatalf("exp=freelist; got=%v", typ)
-	}
-	if typ := (&Page{flags: 20000}).Typ(); typ != "unknown<4e20>" {
-		t.Fatalf("exp=unknown<4e20>; got=%v", typ)
-	}
+	typ := (&Page{flags: BranchPageFlag}).Typ()
+	require.Equalf(t, "branch", typ, "exp=branch; got=%v", typ)
+	typ = (&Page{flags: LeafPageFlag}).Typ()
+	require.Equalf(t, "leaf", typ, "exp=leaf; got=%v", typ)
+	typ = (&Page{flags: MetaPageFlag}).Typ()
+	require.Equalf(t, "meta", typ, "exp=meta; got=%v", typ)
+	typ = (&Page{flags: FreelistPageFlag}).Typ()
+	require.Equalf(t, "freelist", typ, "exp=freelist; got=%v", typ)
+	typ = (&Page{flags: 20000}).Typ()
+	require.Equalf(t, "unknown<4e20>", typ, "exp=unknown<4e20>; got=%v", typ)
 }
 
 // Ensure that the hexdump debugging function doesn't blow up.
@@ -35,20 +33,16 @@ func TestPgids_merge(t *testing.T) {
 	a := Pgids{4, 5, 6, 10, 11, 12, 13, 27}
 	b := Pgids{1, 3, 8, 9, 25, 30}
 	c := a.Merge(b)
-	if !reflect.DeepEqual(c, Pgids{1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30}) {
-		t.Errorf("mismatch: %v", c)
-	}
+	assert.Truef(t, reflect.DeepEqual(c, Pgids{1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30}), "mismatch: %v", c)
 
 	a = Pgids{4, 5, 6, 10, 11, 12, 13, 27, 35, 36}
 	b = Pgids{8, 9, 25, 30}
 	c = a.Merge(b)
-	if !reflect.DeepEqual(c, Pgids{4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30, 35, 36}) {
-		t.Errorf("mismatch: %v", c)
-	}
+	assert.Truef(t, reflect.DeepEqual(c, Pgids{4, 5, 6, 8, 9, 10, 11, 12, 13, 25, 27, 30, 35, 36}), "mismatch: %v", c)
 }
 
 func TestPgids_merge_quick(t *testing.T) {
-	if err := quick.Check(func(a, b Pgids) bool {
+	err := quick.Check(func(a, b Pgids) bool {
 		// Sort incoming lists.
 		sort.Sort(a)
 		sort.Sort(b)
@@ -66,7 +60,6 @@ func TestPgids_merge_quick(t *testing.T) {
 		}
 
 		return true
-	}, nil); err != nil {
-		t.Fatal(err)
-	}
+	}, nil)
+	require.NoError(t, err)
 }

--- a/internal/freelist/array_test.go
+++ b/internal/freelist/array_test.go
@@ -14,43 +14,31 @@ func TestFreelistArray_allocate(t *testing.T) {
 	f := NewArrayFreelist()
 	ids := []common.Pgid{3, 4, 5, 6, 7, 9, 12, 13, 18}
 	f.Init(ids)
-	if id := int(f.Allocate(1, 3)); id != 3 {
-		t.Fatalf("exp=3; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 1)); id != 6 {
-		t.Fatalf("exp=6; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 3)); id != 0 {
-		t.Fatalf("exp=0; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 2)); id != 12 {
-		t.Fatalf("exp=12; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 1)); id != 7 {
-		t.Fatalf("exp=7; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 0)); id != 0 {
-		t.Fatalf("exp=0; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 0)); id != 0 {
-		t.Fatalf("exp=0; got=%v", id)
-	}
-	if exp := common.Pgids([]common.Pgid{9, 18}); !reflect.DeepEqual(exp, f.freePageIds()) {
-		t.Fatalf("exp=%v; got=%v", exp, f.freePageIds())
-	}
+	id := int(f.Allocate(1, 3))
+	require.Equalf(t, 3, id, "exp=3; got=%v", id)
+	id = int(f.Allocate(1, 1))
+	require.Equalf(t, 6, id, "exp=6; got=%v", id)
+	id = int(f.Allocate(1, 3))
+	require.Equalf(t, 0, id, "exp=0; got=%v", id)
+	id = int(f.Allocate(1, 2))
+	require.Equalf(t, 12, id, "exp=12; got=%v", id)
+	id = int(f.Allocate(1, 1))
+	require.Equalf(t, 7, id, "exp=7; got=%v", id)
+	id = int(f.Allocate(1, 0))
+	require.Equalf(t, 0, id, "exp=0; got=%v", id)
+	id = int(f.Allocate(1, 0))
+	require.Equalf(t, 0, id, "exp=0; got=%v", id)
+	exp := common.Pgids([]common.Pgid{9, 18})
+	require.Truef(t, reflect.DeepEqual(exp, f.freePageIds()), "exp=%v; got=%v", exp, f.freePageIds())
 
-	if id := int(f.Allocate(1, 1)); id != 9 {
-		t.Fatalf("exp=9; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 1)); id != 18 {
-		t.Fatalf("exp=18; got=%v", id)
-	}
-	if id := int(f.Allocate(1, 1)); id != 0 {
-		t.Fatalf("exp=0; got=%v", id)
-	}
-	if exp := common.Pgids([]common.Pgid{}); !reflect.DeepEqual(exp, f.freePageIds()) {
-		t.Fatalf("exp=%v; got=%v", exp, f.freePageIds())
-	}
+	id = int(f.Allocate(1, 1))
+	require.Equalf(t, 9, id, "exp=9; got=%v", id)
+	id = int(f.Allocate(1, 1))
+	require.Equalf(t, 18, id, "exp=18; got=%v", id)
+	id = int(f.Allocate(1, 1))
+	require.Equalf(t, 0, id, "exp=0; got=%v", id)
+	exp = common.Pgids([]common.Pgid{})
+	require.Truef(t, reflect.DeepEqual(exp, f.freePageIds()), "exp=%v; got=%v", exp, f.freePageIds())
 }
 
 func TestInvalidArrayAllocation(t *testing.T) {

--- a/internal/freelist/hashmap_test.go
+++ b/internal/freelist/hashmap_test.go
@@ -26,23 +26,19 @@ func TestFreelistHashmap_allocate(t *testing.T) {
 	f.Init(ids)
 
 	f.Allocate(1, 3)
-	if x := f.FreeCount(); x != 6 {
-		t.Fatalf("exp=6; got=%v", x)
-	}
+	x := f.FreeCount()
+	require.Equalf(t, 6, x, "exp=6; got=%v", x)
 
 	f.Allocate(1, 2)
-	if x := f.FreeCount(); x != 4 {
-		t.Fatalf("exp=4; got=%v", x)
-	}
+	x = f.FreeCount()
+	require.Equalf(t, 4, x, "exp=4; got=%v", x)
 	f.Allocate(1, 1)
-	if x := f.FreeCount(); x != 3 {
-		t.Fatalf("exp=3; got=%v", x)
-	}
+	x = f.FreeCount()
+	require.Equalf(t, 3, x, "exp=3; got=%v", x)
 
 	f.Allocate(1, 0)
-	if x := f.FreeCount(); x != 3 {
-		t.Fatalf("exp=3; got=%v", x)
-	}
+	x = f.FreeCount()
+	require.Equalf(t, 3, x, "exp=3; got=%v", x)
 }
 
 func TestFreelistHashmap_mergeWithExist(t *testing.T) {
@@ -101,18 +97,10 @@ func TestFreelistHashmap_mergeWithExist(t *testing.T) {
 
 		f.mergeWithExistingSpan(tt.pgid)
 
-		if got := f.freePageIds(); !reflect.DeepEqual(tt.want, got) {
-			t.Fatalf("name %s; exp=%v; got=%v", tt.name, tt.want, got)
-		}
-		if got := f.forwardMap; !reflect.DeepEqual(tt.wantForwardmap, got) {
-			t.Fatalf("name %s; exp=%v; got=%v", tt.name, tt.wantForwardmap, got)
-		}
-		if got := f.backwardMap; !reflect.DeepEqual(tt.wantBackwardmap, got) {
-			t.Fatalf("name %s; exp=%v; got=%v", tt.name, tt.wantBackwardmap, got)
-		}
-		if got := f.freemaps; !reflect.DeepEqual(tt.wantfreemap, got) {
-			t.Fatalf("name %s; exp=%v; got=%v", tt.name, tt.wantfreemap, got)
-		}
+		require.Truef(t, reflect.DeepEqual(tt.want, f.freePageIds()), "name %s; exp=%v; got=%v", tt.name, tt.want, f.freePageIds())
+		require.Truef(t, reflect.DeepEqual(tt.wantForwardmap, f.forwardMap), "name %s; exp=%v; got=%v", tt.name, tt.wantForwardmap, f.forwardMap)
+		require.Truef(t, reflect.DeepEqual(tt.wantBackwardmap, f.backwardMap), "name %s; exp=%v; got=%v", tt.name, tt.wantBackwardmap, f.backwardMap)
+		require.Truef(t, reflect.DeepEqual(tt.wantfreemap, f.freemaps), "name %s; exp=%v; got=%v", tt.name, tt.wantfreemap, f.freemaps)
 	}
 }
 
@@ -133,9 +121,7 @@ func TestFreelistHashmap_GetFreePageIDs(t *testing.T) {
 	f.forwardMap = fm
 	res := f.freePageIds()
 
-	if !sort.SliceIsSorted(res, func(i, j int) bool { return res[i] < res[j] }) {
-		t.Fatalf("pgids not sorted")
-	}
+	require.Truef(t, sort.SliceIsSorted(res, func(i, j int) bool { return res[i] < res[j] }), "pgids not sorted")
 }
 
 func Test_Freelist_Hashmap_Rollback(t *testing.T) {

--- a/internal/surgeon/surgeon_test.go
+++ b/internal/surgeon/surgeon_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	bolt "go.etcd.io/bbolt"
 	"go.etcd.io/bbolt/internal/btesting"
@@ -41,7 +42,7 @@ func TestRevertMetaPage(t *testing.T) {
 	db.Close()
 
 	// This causes the whole tree to be linked to the previous state
-	assert.NoError(t, surgeon.RevertMetaPage(db.Path()))
+	require.NoError(t, surgeon.RevertMetaPage(db.Path()))
 
 	db.MustReopen()
 	db.MustCheck()

--- a/internal/surgeon/xray_test.go
+++ b/internal/surgeon/xray_test.go
@@ -24,12 +24,12 @@ func TestFindPathsToKey(t *testing.T) {
 
 	navigator := surgeon.NewXRay(db.Path())
 	path1, err := navigator.FindPathsToKey([]byte("0451"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, path1)
 
 	page := path1[0][len(path1[0])-1]
 	p, _, err := guts_cli.ReadPage(db.Path(), uint64(page))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.GreaterOrEqual(t, []byte("0451"), p.LeafPageElement(0).Key())
 	assert.LessOrEqual(t, []byte("0451"), p.LeafPageElement(p.Count()-1).Key())
 }
@@ -55,12 +55,12 @@ func TestFindPathsToKey_Bucket(t *testing.T) {
 
 	navigator := surgeon.NewXRay(db.Path())
 	path1, err := navigator.FindPathsToKey(subBucket)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotEmpty(t, path1)
 
 	page := path1[0][len(path1[0])-1]
 	p, _, err := guts_cli.ReadPage(db.Path(), uint64(page))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.GreaterOrEqual(t, subBucket, p.LeafPageElement(0).Key())
 	assert.LessOrEqual(t, subBucket, p.LeafPageElement(p.Count()-1).Key())
 }

--- a/internal/tests/tx_check_test.go
+++ b/internal/tests/tx_check_test.go
@@ -25,12 +25,12 @@ func TestTx_RecursivelyCheckPages_MisplacedPage(t *testing.T) {
 	xRay := surgeon.NewXRay(db.Path())
 
 	path1, err := xRay.FindPathsToKey([]byte("0451"))
-	require.NoError(t, err, "cannot find page that contains key:'0451'")
-	require.Len(t, path1, 1, "Expected only one page that contains key:'0451'")
+	require.NoErrorf(t, err, "cannot find page that contains key:'0451'")
+	require.Lenf(t, path1, 1, "Expected only one page that contains key:'0451'")
 
 	path2, err := xRay.FindPathsToKey([]byte("7563"))
-	require.NoError(t, err, "cannot find page that contains key:'7563'")
-	require.Len(t, path2, 1, "Expected only one page that contains key:'7563'")
+	require.NoErrorf(t, err, "cannot find page that contains key:'7563'")
+	require.Lenf(t, path2, 1, "Expected only one page that contains key:'7563'")
 
 	srcPage := path1[0][len(path1[0])-1]
 	targetPage := path2[0][len(path2[0])-1]
@@ -64,13 +64,13 @@ func TestTx_RecursivelyCheckPages_CorruptedLeaf(t *testing.T) {
 	xray := surgeon.NewXRay(db.Path())
 
 	path1, err := xray.FindPathsToKey([]byte("0451"))
-	require.NoError(t, err, "cannot find page that contains key:'0451'")
-	require.Len(t, path1, 1, "Expected only one page that contains key:'0451'")
+	require.NoErrorf(t, err, "cannot find page that contains key:'0451'")
+	require.Lenf(t, path1, 1, "Expected only one page that contains key:'0451'")
 
 	srcPage := path1[0][len(path1[0])-1]
 	p, pbuf, err := guts_cli.ReadPage(db.Path(), uint64(srcPage))
 	require.NoError(t, err)
-	require.Positive(t, p.Count(), "page must be not empty")
+	require.Positivef(t, p.Count(), "page must be not empty")
 	p.LeafPageElement(p.Count() / 2).Key()[0] = 'z'
 	require.NoError(t, guts_cli.WritePage(db.Path(), pbuf))
 

--- a/manydbs_test.go
+++ b/manydbs_test.go
@@ -6,21 +6,19 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func createDb(t *testing.T) (*DB, func()) {
 	// First, create a temporary directory to be used for the duration of
 	// this test.
 	tempDirName, err := os.MkdirTemp("", "bboltmemtest")
-	if err != nil {
-		t.Fatalf("error creating temp dir: %v", err)
-	}
+	require.NoErrorf(t, err, "error creating temp dir: %v", err)
 	path := filepath.Join(tempDirName, "testdb.db")
 
 	bdb, err := Open(path, 0600, nil)
-	if err != nil {
-		t.Fatalf("error creating bbolt db: %v", err)
-	}
+	require.NoErrorf(t, err, "error creating bbolt db: %v", err)
 
 	cleanup := func() {
 		bdb.Close()
@@ -56,9 +54,7 @@ func createAndPutKeys(t *testing.T) {
 
 			return nil
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 	}
 }
 

--- a/movebucket_test.go
+++ b/movebucket_test.go
@@ -364,13 +364,13 @@ func openBucket(tx *bbolt.Tx, bk *bbolt.Bucket, bucketToOpen string) *bbolt.Buck
 func createBucketAndPopulateData(t testing.TB, tx *bbolt.Tx, bk *bbolt.Bucket, bucketName string) *bbolt.Bucket {
 	if bk == nil {
 		newBucket, err := tx.CreateBucket([]byte(bucketName))
-		require.NoError(t, err, "failed to create bucket %s", bucketName)
+		require.NoErrorf(t, err, "failed to create bucket %s", bucketName)
 		populateSampleDataInBucket(t, newBucket, rand.Intn(4096))
 		return newBucket
 	}
 
 	newBucket, err := bk.CreateBucket([]byte(bucketName))
-	require.NoError(t, err, "failed to create bucket %s", bucketName)
+	require.NoErrorf(t, err, "failed to create bucket %s", bucketName)
 	populateSampleDataInBucket(t, newBucket, rand.Intn(4096))
 	return newBucket
 }

--- a/simulation_test.go
+++ b/simulation_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	bolt "go.etcd.io/bbolt"
 	"go.etcd.io/bbolt/internal/btesting"
 )
@@ -138,9 +140,7 @@ func testSimulate(t *testing.T, openOption *bolt.Options, round, threadCount, pa
 		t.Logf("transactions:%d ignored:%d", opCount, igCount)
 		close(errCh)
 		for err := range errCh {
-			if err != nil {
-				t.Fatalf("error from inside goroutine: %v", err)
-			}
+			require.NoErrorf(t, err, "error from inside goroutine: %v", err)
 		}
 
 		db.MustClose()

--- a/tests/dmflakey/dmflakey_test.go
+++ b/tests/dmflakey/dmflakey_test.go
@@ -3,7 +3,6 @@
 package dmflakey
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -31,7 +30,7 @@ func TestBasic(t *testing.T) {
 			tmpDir := t.TempDir()
 
 			flakey, err := InitFlakey("go-dmflakey", tmpDir, fsType, "")
-			require.NoError(t, err, "init flakey")
+			require.NoErrorf(t, err, "init flakey")
 			defer func() {
 				assert.NoError(t, flakey.Teardown())
 			}()
@@ -79,11 +78,11 @@ func TestDropWritesExt4(t *testing.T) {
 	require.NoError(t, mount(root, flakey.DevicePath(), ""))
 
 	data, err := os.ReadFile(f1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "hello, world from f1", string(data))
 
 	_, err = os.ReadFile(f2)
-	assert.True(t, errors.Is(err, os.ErrNotExist))
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestErrorWritesExt4(t *testing.T) {
@@ -97,10 +96,10 @@ func TestErrorWritesExt4(t *testing.T) {
 
 	f1 := filepath.Join(root, "f1")
 	err := writeFile(f1, []byte("hello, world during failpoint"), 0600, true)
-	assert.ErrorContains(t, err, "input/output error")
+	require.ErrorContains(t, err, "input/output error")
 
 	// resume
-	assert.NoError(t, flakey.AllowWrites())
+	require.NoError(t, flakey.AllowWrites())
 	err = writeFile(f1, []byte("hello, world"), 0600, true)
 	assert.NoError(t, err)
 
@@ -108,7 +107,7 @@ func TestErrorWritesExt4(t *testing.T) {
 	require.NoError(t, mount(root, flakey.DevicePath(), ""))
 
 	data, err := os.ReadFile(f1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "hello, world", string(data))
 }
 
@@ -119,7 +118,7 @@ func initFlakey(t *testing.T, fsType FSType) (_ Flakey, root string) {
 	require.NoError(t, os.MkdirAll(target, 0600))
 
 	flakey, err := InitFlakey("go-dmflakey", tmpDir, fsType, "")
-	require.NoError(t, err, "init flakey")
+	require.NoErrorf(t, err, "init flakey")
 
 	t.Cleanup(func() {
 		assert.NoError(t, unmount(target))

--- a/tx_check_test.go
+++ b/tx_check_test.go
@@ -39,7 +39,7 @@ func TestTx_Check_CorruptPage(t *testing.T) {
 		for cErr := range errChan {
 			cErrs = append(cErrs, cErr)
 		}
-		require.Greater(t, len(cErrs), 0)
+		require.NotEmpty(t, cErrs)
 
 		t.Log("Check valid pages.")
 		cErrs = cErrs[:0]
@@ -48,7 +48,7 @@ func TestTx_Check_CorruptPage(t *testing.T) {
 			for cErr := range errChan {
 				cErrs = append(cErrs, cErr)
 			}
-			require.Equal(t, 0, len(cErrs))
+			require.Empty(t, cErrs)
 		}
 		return nil
 	})
@@ -108,7 +108,7 @@ func TestTx_Check_WithNestBucket(t *testing.T) {
 		for cErr := range errChan {
 			cErrs = append(cErrs, cErr)
 		}
-		require.Equal(t, 0, len(cErrs))
+		require.Empty(t, cErrs)
 
 		return nil
 	})
@@ -139,7 +139,7 @@ func corruptRandomLeafPageInBucket(t testing.TB, db *bbolt.DB, bucketName []byte
 	victimPage, victimBuf, err := guts_cli.ReadPage(db.Path(), uint64(victimPageId))
 	require.NoError(t, err)
 	require.True(t, victimPage.IsLeafPage())
-	require.True(t, victimPage.Count() > 1)
+	require.Greater(t, victimPage.Count(), uint16(1))
 
 	// intentionally make the second key < the first key.
 	element := victimPage.LeafPageElement(1)

--- a/unix_test.go
+++ b/unix_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
 	bolt "go.etcd.io/bbolt"
@@ -26,22 +28,17 @@ func TestMlock_DbCanGrow_Small(t *testing.T) {
 
 	db := btesting.MustCreateDBWithOption(t, &bolt.Options{Mlock: true})
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte("bucket"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		key := []byte("key")
 		value := []byte("value")
-		if err := b.Put(key, value); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, b.Put(key, value))
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 
 }
 
@@ -69,41 +66,32 @@ func TestMlock_DbCanGrow_Big(t *testing.T) {
 	}
 	newDbSize := fileSize(db.Path())
 
-	if newDbSize <= dbSize {
-		t.Errorf("db didn't grow: %v <= %v", newDbSize, dbSize)
-	}
+	assert.Greaterf(t, newDbSize, dbSize, "db didn't grow: %v <= %v", newDbSize, dbSize)
 }
 
 func insertChunk(t *testing.T, db *btesting.DB, chunkId int) {
 	chunkSize := 1024
 
-	if err := db.Update(func(tx *bolt.Tx) error {
+	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte("bucket"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		for i := 0; i < chunkSize; i++ {
 			key := []byte(fmt.Sprintf("key-%d-%d", chunkId, i))
 			value := []byte("value")
-			if err := b.Put(key, value); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, b.Put(key, value))
 		}
 
 		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
+	})
+	require.NoError(t, err)
 }
 
 // Main reason for this check is travis limiting mlockable memory to 64KB
 // https://github.com/travis-ci/travis-ci/issues/2462
 func skipOnMemlockLimitBelow(t *testing.T, memlockLimitRequest uint64) {
 	var info unix.Rlimit
-	if err := unix.Getrlimit(unix.RLIMIT_MEMLOCK, &info); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, unix.Getrlimit(unix.RLIMIT_MEMLOCK, &info))
 
 	if info.Cur < memlockLimitRequest {
 		t.Skipf(


### PR DESCRIPTION
#### Description

Enables testifylint linter and uses testify instead of t.Fatal(f)