### PR TITLE
Use GitHub runners for arm64 robustness tests

### DIFF
--- a/.github/workflows/robustness_test.yaml
+++ b/.github/workflows/robustness_test.yaml
@@ -8,3 +8,9 @@ jobs:
       count: 10
       testTimeout: 30m
       runs-on: "['ubuntu-latest']"
+  arm64:
+    uses: ./.github/workflows/robustness_template.yaml
+    with:
+      count: 10
+      testTimeout: 30m
+      runs-on: "['ubuntu-24.04-arm']"

--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -15,8 +15,6 @@ permissions: read-all
 
 jobs:
   test-linux:
-    # this is to prevent arm64 jobs from running at forked projects
-    if: ${{ github.repository == 'etcd-io/bbolt' || inputs.runs-on == 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests_arm64.yaml
+++ b/.github/workflows/tests_arm64.yaml
@@ -1,0 +1,26 @@
+---
+name: Tests ARM64
+permissions: read-all
+on: [push, pull_request]
+jobs:
+  test-linux-arm64:
+    uses: ./.github/workflows/tests-template.yml
+  test-linux-arm64-race:
+    uses: ./.github/workflows/tests-template.yml
+    with:
+      runs-on: ubuntu-24.04-arm
+      targets: "['linux-unit-test-4-cpu-race']"
+
+  coverage:
+    needs:
+      - test-linux-arm64
+      - test-linux-arm64-race
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - id: goversion
+        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: ${{ steps.goversion.outputs.goversion }}
+      - run: make coverage


### PR DESCRIPTION
Follow up on #917.

GitGub [recently launched ARM64 Linux runners](https://github.com/orgs/community/discussions/148648). Because we're facing dead ends trying to run them in the Prow infra (https://github.com/kubernetes/test-infra/issues/33737), it may even be more complicated to maintain. This should be a good option for the time being.

Part of https://github.com/etcd-io/bbolt/issues/848