### PR TITLE
Clarify the effect of InitialMmapSize on Windows platform

### DIFF
--- a/db.go
+++ b/db.go
@@ -1309,6 +1309,12 @@ type Options struct {
 	// If <=0, the initial map size is 0.
 	// If initialMmapSize is smaller than the previous database size,
 	// it takes no effect.
+	//
+	// Note: On Windows, due to platform limitations, the database file size
+	// will be immediately resized to match `InitialMmapSize` (aligned to page size)
+	// when the DB is opened. On non-Windows platforms, the file size will grow
+	// dynamically based on the actual amount of written data, regardless of `InitialMmapSize`.
+	// Refer to https://github.com/etcd-io/bbolt/issues/378#issuecomment-1378121966.
 	InitialMmapSize int
 
 	// PageSize overrides the default OS page size.


### PR DESCRIPTION
cc @fuweid @tjungblu 

```
func TestOpenFile(t *testing.T) {
	dbPath := filepath.Join(t.TempDir(), "db")

	db, err := Open(dbPath, 0600, &Options{InitialMmapSize: 2 * 1024 * 1024 * 1024})
	require.NoError(t, err)

	sz, err := db.fileSize()
	require.NoError(t, err)
	t.Logf("###### IN TestOpenFile, file size before close: %d", sz)

	require.NoError(t, db.Close())

	fi, err := os.Stat(dbPath)
	require.NoError(t, err)
	t.Logf("###### IN TestOpenFile, file size after close: %d", fi.Size())
}
```

Linux:
```
=== RUN   TestOpenFile
    db_whitebox_test.go:24: ###### IN TestOpenFile, file size before close: 16384
    db_whitebox_test.go:30: ###### IN TestOpenFile, file size after close: 16384
```

Windows:
```
=== RUN   TestOpenFile
    db_whitebox_test.go:22: ###### IN TestOpenFile, file size before close: 2147483648
    db_whitebox_test.go:28: ###### IN TestOpenFile, file size after close: 2147483648
```