### PR TITLE
chore: bump golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -50,6 +50,6 @@ jobs:
               ;;
           esac
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.5
+          version: v2.1.6

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -40,9 +40,9 @@ jobs:
           esac
         shell: bash
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.5
+          version: v2.1.6
 
   coverage:
     needs: ["test-windows"]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,16 +1,39 @@
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings: # please keep this alphabetized
+    goimports:
+      local-prefixes:
+        - go.etcd.io # Put imports beginning with prefix after 3rd-party packages.
 issues:
   max-same-issues: 0
 linters:
-  disable-all: true
+  default: none
   enable: # please keep this alphabetized
     - errcheck
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
-linters-settings: # please keep this alphabetized
-  goimports:
-    local-prefixes: go.etcd.io # Put imports beginning with prefix after 3rd-party packages.
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+  settings: # please keep this alphabetized
+    staticcheck:
+      checks:
+        - all
+        - -QF1003 # Convert if/else-if chain to tagged switch
+        - -QF1004 # Use strings.ReplaceAll instead of strings.Replace with n == -1
+        - -QF1010 # Convert slice of bytes to string when printing it
+        - -QF1011 # Omit redundant type from variable declaration
+        - -ST1003 # Poorly chosen identifier
+        - -ST1005 # Incorrectly formatted error string
+        - -ST1006 # Poorly chosen receiver name
+        - -ST1012 # Poorly chosen name for error variable
+        - -ST1016 # Use consistent method receiver names
+        - -ST1023 # Redundant type in variable declaration
+version: "2"


### PR DESCRIPTION
#### Description


bump golangci-lint to v2.1.6 and golangci/golangci-lint-action to 8.0.0

This **is not** fixing the new issues discovered


Closes #951