### PR TITLE
fix staticcheck issues

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,13 +27,8 @@ linters:
       checks:
         - all
         - -QF1003 # Convert if/else-if chain to tagged switch
-        - -QF1004 # Use strings.ReplaceAll instead of strings.Replace with n == -1
         - -QF1010 # Convert slice of bytes to string when printing it
-        - -QF1011 # Omit redundant type from variable declaration
         - -ST1003 # Poorly chosen identifier
         - -ST1005 # Incorrectly formatted error string
-        - -ST1006 # Poorly chosen receiver name
         - -ST1012 # Poorly chosen name for error variable
-        - -ST1016 # Use consistent method receiver names
-        - -ST1023 # Redundant type in variable declaration
 version: "2"

--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -1768,11 +1768,11 @@ Additional options include:
 
 type cmdKvStringer struct{}
 
-func (_ cmdKvStringer) KeyToString(key []byte) string {
+func (cmdKvStringer) KeyToString(key []byte) string {
 	return bytesToAsciiOrHex(key)
 }
 
-func (_ cmdKvStringer) ValueToString(value []byte) string {
+func (cmdKvStringer) ValueToString(value []byte) string {
 	return bytesToAsciiOrHex(value)
 }
 
@@ -1781,7 +1781,7 @@ func CmdKvStringer() bolt.KVStringer {
 }
 
 func findLastBucket(tx *bolt.Tx, bucketNames []string) (*bolt.Bucket, error) {
-	var lastbucket *bolt.Bucket = tx.Bucket([]byte(bucketNames[0]))
+	lastbucket := tx.Bucket([]byte(bucketNames[0]))
 	if lastbucket == nil {
 		return nil, berrors.ErrBucketNotFound
 	}

--- a/internal/common/page.go
+++ b/internal/common/page.go
@@ -335,16 +335,16 @@ func (s Pgids) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s Pgids) Less(i, j int) bool { return s[i] < s[j] }
 
 // Merge returns the sorted union of a and b.
-func (a Pgids) Merge(b Pgids) Pgids {
+func (s Pgids) Merge(b Pgids) Pgids {
 	// Return the opposite slice if one is nil.
-	if len(a) == 0 {
+	if len(s) == 0 {
 		return b
 	}
 	if len(b) == 0 {
-		return a
+		return s
 	}
-	merged := make(Pgids, len(a)+len(b))
-	Mergepgids(merged, a, b)
+	merged := make(Pgids, len(s)+len(b))
+	Mergepgids(merged, s, b)
 	return merged
 }
 

--- a/tests/robustness/powerfailure_test.go
+++ b/tests/robustness/powerfailure_test.go
@@ -140,7 +140,7 @@ func TestRestartFromPowerFailureXFS(t *testing.T) {
 }
 
 func doPowerFailure(t *testing.T, du time.Duration, fsType dmflakey.FSType, mkfsOpt string, fsMountOpt string, useFailpoint bool) {
-	flakey := initFlakeyDevice(t, strings.Replace(t.Name(), "/", "_", -1), fsType, mkfsOpt, fsMountOpt)
+	flakey := initFlakeyDevice(t, strings.ReplaceAll(t.Name(), "/", "_"), fsType, mkfsOpt, fsMountOpt)
 	root := flakey.RootFS()
 
 	dbPath := filepath.Join(root, "boltdb")

--- a/tx_check.go
+++ b/tx_check.go
@@ -281,10 +281,10 @@ func HexKVStringer() KVStringer {
 
 type hexKvStringer struct{}
 
-func (_ hexKvStringer) KeyToString(key []byte) string {
+func (hexKvStringer) KeyToString(key []byte) string {
 	return hex.EncodeToString(key)
 }
 
-func (_ hexKvStringer) ValueToString(value []byte) string {
+func (hexKvStringer) ValueToString(value []byte) string {
 	return hex.EncodeToString(value)
 }


### PR DESCRIPTION
#### Description

Enable and fixes rules from staticcheck, one rule per commit: 

* [QF1004](https://staticcheck.dev/docs/checks/#QF1004): Use strings.ReplaceAll instead of strings.Replace with n == -1
* [QF1011](https://staticcheck.dev/docs/checks/#QF1011): Omit redundant type from variable declaration
* [ST1006](https://staticcheck.dev/docs/checks/#ST1006): Poorly chosen receiver name
* [ST1016](https://staticcheck.dev/docs/checks/#ST1016): Use consistent method receiver names
* [ST1023](https://staticcheck.dev/docs/checks/#ST1023): Redundant type in variable declaration
