### PR TITLE
Support customizing the rebalance threshold

### DIFF
--- a/node.go
+++ b/node.go
@@ -371,8 +371,16 @@ func (n *node) rebalance() {
 	// Update statistics.
 	n.bucket.tx.stats.IncRebalance(1)
 
-	// Ignore if node is above threshold (25% when FillPercent is set to DefaultFillPercent) and has enough keys.
-	var threshold = int(float64(n.bucket.tx.db.pageSize)*n.bucket.FillPercent) / 2
+	// Determine the threshold before starting to rebalance.
+	var rebalancePercent = n.bucket.RebalancePercent
+	if rebalancePercent < minRebalancePercent {
+		rebalancePercent = minRebalancePercent
+	} else if rebalancePercent > maxRebalancePercent {
+		rebalancePercent = maxRebalancePercent
+	}
+	threshold := int(float64(n.bucket.tx.db.pageSize) * rebalancePercent)
+
+	// Ignore if node is above threshold (25% by default) and has enough keys.
 	if n.size() > threshold && len(n.inodes) > n.minKeys() {
 		return
 	}


### PR DESCRIPTION
I am **NOT** targeting to merge this PR. Just for others reference.

I did not see much differences (default RebalancePercent `0.25` vs customised value `0.9` ) on the disk usage of etcd db using the tool [fragcheck](https://github.com/ahrtr/etcd-issues/tree/master/etcd/fragcheck) with all the default parameters. 

There might be some differences in a long time test. Setting a big RebalancePercent will trigger a page (which has deleted entries) to be merged with its sibling more easily, but it may be split again soon (if the merged page exceeds one page size), however it isn't an even split.

Assuming the page uses 60% of the space, and its sibling also uses 60% of the page; the outcome is the left page will have 90% fill percent (assuming FillPercent is 0.9), while the right one will have only 30% fill percent. Obviously the right page will be more easily merged with its sibling in future during rebalance.

One idea is to merge multiple sibling pages at a time depending on the fill percent of each page. When it splits again, only one page may have small fill percent, all other pages will have the highest fill percent. So the benefit is that we make most use of the page spaces.

But this solution has several flaws,
- It only makes most use of each page's space, but it doesn't resolve how to reclaim the unused free pages. Users still need to run compact or defragmentation.
- It might increase the duration to process each transaction, so hurt the performance.

So I don't see a perfect way to handle etcd (bbolt)'s fragmentations (including both scattered free pages and unused space in each page). It should be a restriction caused by bbolt built-in property (B+tree).

cc @fuweid @tjungblu @benbjohnson 
