### PR TITLE
chore: use %w to wrap  returned err by unix funcs

### DIFF
--- a/db.go
+++ b/db.go
@@ -552,7 +552,7 @@ func (db *DB) munmap() error {
 	// return errors.New(unmapError)
 	if err := munmap(db); err != nil {
 		db.Logger().Errorf("[GOOS: %s, GOARCH: %s] munmap failed, db.datasz: %d, error: %v", runtime.GOOS, runtime.GOARCH, db.datasz, err)
-		return fmt.Errorf("unmap error: %v", err.Error())
+		return fmt.Errorf("unmap error: %w", err)
 	}
 
 	return nil
@@ -600,7 +600,7 @@ func (db *DB) munlock(fileSize int) error {
 	// return errors.New(munlockError)
 	if err := munlock(db, fileSize); err != nil {
 		db.Logger().Errorf("[GOOS: %s, GOARCH: %s] munlock failed, fileSize: %d, db.datasz: %d, error: %v", runtime.GOOS, runtime.GOARCH, fileSize, db.datasz, err)
-		return fmt.Errorf("munlock error: %v", err.Error())
+		return fmt.Errorf("munlock error: %w", err)
 	}
 	return nil
 }
@@ -610,7 +610,7 @@ func (db *DB) mlock(fileSize int) error {
 	// return errors.New(mlockError)
 	if err := mlock(db, fileSize); err != nil {
 		db.Logger().Errorf("[GOOS: %s, GOARCH: %s] mlock failed, fileSize: %d, db.datasz: %d, error: %v", runtime.GOOS, runtime.GOARCH, fileSize, db.datasz, err)
-		return fmt.Errorf("mlock error: %v", err.Error())
+		return fmt.Errorf("mlock error: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Golang provides the fmt.Errorf("xxx: %w", err) mechanism to return errors and add new context. We can use this mechanism to provide upstream callers with the opportunity to handle specific errors.

docs: https://pkg.go.dev/fmt#Errorf