### PR TITLE
Improve RO transaction setup

### DIFF
--- a/concurrent_test.go
+++ b/concurrent_test.go
@@ -971,7 +971,8 @@ func TestConcurrentView(t *testing.T) {
 	)
 
 	db := mustCreateDB(t, &bolt.Options{
-		PageSize: 4096,
+		PageSize:     4096,
+		NoStatistics: true,
 	})
 	err := db.Update(func(tx *bolt.Tx) error {
 		b, err := tx.CreateBucketIfNotExists([]byte(bucketPrefix))

--- a/db.go
+++ b/db.go
@@ -36,12 +36,6 @@ const (
 // All data access is performed through transactions which can be obtained through the DB.
 // All the functions on DB will return a ErrDatabaseNotOpen if accessed before Open() is called.
 type DB struct {
-	// Put `stats` at the first field to ensure it's 64-bit aligned. Note that
-	// the first word in an allocated struct can be relied upon to be 64-bit
-	// aligned. Refer to https://pkg.go.dev/sync/atomic#pkg-note-BUG. Also
-	// refer to discussion in https://github.com/etcd-io/bbolt/issues/577.
-	stats Stats
-
 	// When enabled, the database will perform a Check() after every commit.
 	// A panic is issued if the database is in an inconsistent state. This
 	// flag has a large performance impact so it should only be used for
@@ -132,6 +126,7 @@ type DB struct {
 	pageSize int
 	opened   bool
 	rwtx     *Tx
+	stats    *Stats
 
 	freelist     fl.Interface
 	freelistLoad sync.Once
@@ -195,6 +190,10 @@ func Open(path string, mode os.FileMode, options *Options) (db *DB, err error) {
 	db.MaxBatchSize = common.DefaultMaxBatchSize
 	db.MaxBatchDelay = common.DefaultMaxBatchDelay
 	db.AllocSize = common.DefaultAllocSize
+
+	if !options.NoStatistics {
+		db.stats = new(Stats)
+	}
 
 	if options.Logger == nil {
 		db.logger = getDiscardLogger()
@@ -423,7 +422,9 @@ func (db *DB) loadFreelist() {
 			// Read free list from freelist page.
 			db.freelist.Read(db.page(db.meta().Freelist()))
 		}
-		db.stats.FreePageN = db.freelist.FreeCount()
+		if db.stats != nil {
+			db.stats.FreePageN = db.freelist.FreeCount()
+		}
 	})
 }
 
@@ -801,10 +802,12 @@ func (db *DB) beginTx() (*Tx, error) {
 	db.metalock.Unlock()
 
 	// Update the transaction stats.
-	db.statlock.Lock()
-	db.stats.TxN++
-	db.stats.OpenTxN++
-	db.statlock.Unlock()
+	if db.stats != nil {
+		db.statlock.Lock()
+		db.stats.TxN++
+		db.stats.OpenTxN++
+		db.statlock.Unlock()
+	}
 
 	return t, nil
 }
@@ -860,10 +863,12 @@ func (db *DB) removeTx(tx *Tx) {
 	db.metalock.Unlock()
 
 	// Merge statistics.
-	db.statlock.Lock()
-	db.stats.OpenTxN--
-	db.stats.TxStats.add(&tx.stats)
-	db.statlock.Unlock()
+	if db.stats != nil {
+		db.statlock.Lock()
+		db.stats.OpenTxN--
+		db.stats.TxStats.add(&tx.stats)
+		db.statlock.Unlock()
+	}
 }
 
 // Update executes a function within the context of a read-write managed transaction.
@@ -1081,9 +1086,13 @@ func (db *DB) Sync() (err error) {
 // Stats retrieves ongoing performance stats for the database.
 // This is only updated when a transaction closes.
 func (db *DB) Stats() Stats {
-	db.statlock.RLock()
-	defer db.statlock.RUnlock()
-	return db.stats
+	var s Stats
+	if db.stats != nil {
+		db.statlock.RLock()
+		s = *db.stats
+		db.statlock.RUnlock()
+	}
+	return s
 }
 
 // This is for internal access to the raw data bytes from the C cursor, use
@@ -1321,6 +1330,11 @@ type Options struct {
 
 	// Logger is the logger used for bbolt.
 	Logger Logger
+
+	// NoStatistics turns off statistics collection, Stats method will
+	// return empty structure in this case. This can be beneficial for
+	// performance in some cases.
+	NoStatistics bool
 }
 
 func (o *Options) String() string {
@@ -1328,8 +1342,8 @@ func (o *Options) String() string {
 		return "{}"
 	}
 
-	return fmt.Sprintf("{Timeout: %s, NoGrowSync: %t, NoFreelistSync: %t, PreLoadFreelist: %t, FreelistType: %s, ReadOnly: %t, MmapFlags: %x, InitialMmapSize: %d, PageSize: %d, NoSync: %t, OpenFile: %p, Mlock: %t, Logger: %p}",
-		o.Timeout, o.NoGrowSync, o.NoFreelistSync, o.PreLoadFreelist, o.FreelistType, o.ReadOnly, o.MmapFlags, o.InitialMmapSize, o.PageSize, o.NoSync, o.OpenFile, o.Mlock, o.Logger)
+	return fmt.Sprintf("{Timeout: %s, NoGrowSync: %t, NoFreelistSync: %t, PreLoadFreelist: %t, FreelistType: %s, ReadOnly: %t, MmapFlags: %x, InitialMmapSize: %d, PageSize: %d, NoSync: %t, OpenFile: %p, Mlock: %t, Logger: %p, NoStatistics: %t}",
+		o.Timeout, o.NoGrowSync, o.NoFreelistSync, o.PreLoadFreelist, o.FreelistType, o.ReadOnly, o.MmapFlags, o.InitialMmapSize, o.PageSize, o.NoSync, o.OpenFile, o.Mlock, o.Logger, o.NoStatistics)
 
 }
 

--- a/internal/freelist/freelist.go
+++ b/internal/freelist/freelist.go
@@ -43,7 +43,7 @@ type Interface interface {
 	RemoveReadonlyTXID(txid common.Txid)
 
 	// ReleasePendingPages releases any pages associated with closed read-only transactions.
-	ReleasePendingPages()
+	ReleasePendingPages(txid common.Txid)
 
 	// Free releases a page and its overflow for a given transaction id.
 	// If the page is already free or is one of the meta pages, then a panic will occur.

--- a/tx.go
+++ b/tx.go
@@ -560,7 +560,9 @@ func (tx *Tx) writeMeta() error {
 	lg := tx.db.Logger()
 	buf := make([]byte, tx.db.pageSize)
 	p := tx.db.pageInBuffer(buf, 0)
+	tx.db.metalock.Lock()
 	tx.meta.Write(p)
+	tx.db.metalock.Unlock()
 
 	// Write the meta page to file.
 	if _, err := tx.db.ops.writeAt(buf, int64(p.Id())*int64(tx.db.pageSize)); err != nil {

--- a/tx.go
+++ b/tx.go
@@ -357,13 +357,15 @@ func (tx *Tx) close() {
 		tx.db.rwlock.Unlock()
 
 		// Merge statistics.
-		tx.db.statlock.Lock()
-		tx.db.stats.FreePageN = freelistFreeN
-		tx.db.stats.PendingPageN = freelistPendingN
-		tx.db.stats.FreeAlloc = (freelistFreeN + freelistPendingN) * tx.db.pageSize
-		tx.db.stats.FreelistInuse = freelistAlloc
-		tx.db.stats.TxStats.add(&tx.stats)
-		tx.db.statlock.Unlock()
+		if tx.db.stats != nil {
+			tx.db.statlock.Lock()
+			tx.db.stats.FreePageN = freelistFreeN
+			tx.db.stats.PendingPageN = freelistPendingN
+			tx.db.stats.FreeAlloc = (freelistFreeN + freelistPendingN) * tx.db.pageSize
+			tx.db.stats.FreelistInuse = freelistAlloc
+			tx.db.stats.TxStats.add(&tx.stats)
+			tx.db.statlock.Unlock()
+		}
 	} else {
 		tx.db.removeTx(tx)
 	}


### PR DESCRIPTION
We're using Bolt in https://github.com/nspcc-dev/neofs-node/ (in https://github.com/nspcc-dev/neo-go/ as an option as well) and we recently had a case of some requests processed by node taking much more time than expected in performance tests. It was like the majority of requests served in ~5-6ms with many jumping to 300-500ms, some to 2-4s and we've seen 20+s once as well. After some debugging we found that in this scenario we have a lot of DB readers involved and while "many readers" scenario is exactly where Bolt is good based on our past experience, this time we had a clear difference in time taken by `func(tx *bolt.Tx) error` doing things and `db.View()` wrapping it. Which suggested some problems in transaction management by the DB.

Now the `View()` doesn't do a lot, but still it takes some exclusive locks (which was surprising to me) and after some poking at them we found that they're exactly the problem, it's a classic lock contention which wasn't expected at the level of concurrency we have, but that's what it is. And the most annoying thing about it is that routines losing the race for locks could be seriously penalized, _seconds_ of response time for simple requests are not acceptable (given nice machines with plenty of CPU/RAM) and they seriously affected the averages.

So after some digging in I've cooked up a set of patches that makes our app run fine without these sudden spikes in response time. Now the problem is that this is ~first time I'm looking at the Bolt codebase and even though tests are all green, maybe I'm doing something wrong and I'd really like to get a feedback from people that know this code. My questions are:

1. Is it technically correct at all?
2. Can these patches be merged?
3. How to properly align this with the Bolt release schedule (target branches/release estimates)?
4. Maybe there is some better way to solve these problems?

Currently these patches are based on and targeted for 1.4 (since that's the version we're using). And while many changes are internal, introducing a configuration option is likely not what people want to see in 1.4.1. So maybe we need to think of 1.5 or something else.