### PR TITLE
[release-1.4] Move MaxMapSize and MaxAllocSize into internal common

### DIFF
--- a/bolt_386.go
+++ b/bolt_386.go
@@ -1,7 +1,0 @@
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0x7FFFFFFF // 2GB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0xFFFFFFF

--- a/bolt_amd64.go
+++ b/bolt_amd64.go
@@ -1,7 +1,0 @@
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_arm.go
+++ b/bolt_arm.go
@@ -1,7 +1,0 @@
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0x7FFFFFFF // 2GB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0xFFFFFFF

--- a/bolt_arm64.go
+++ b/bolt_arm64.go
@@ -1,9 +1,0 @@
-//go:build arm64
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_loong64.go
+++ b/bolt_loong64.go
@@ -1,9 +1,0 @@
-//go:build loong64
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_mips64x.go
+++ b/bolt_mips64x.go
@@ -1,9 +1,0 @@
-//go:build mips64 || mips64le
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0x8000000000 // 512GB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_mipsx.go
+++ b/bolt_mipsx.go
@@ -1,9 +1,0 @@
-//go:build mips || mipsle
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0x40000000 // 1GB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0xFFFFFFF

--- a/bolt_ppc.go
+++ b/bolt_ppc.go
@@ -1,9 +1,0 @@
-//go:build ppc
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0x7FFFFFFF // 2GB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0xFFFFFFF

--- a/bolt_ppc64.go
+++ b/bolt_ppc64.go
@@ -1,9 +1,0 @@
-//go:build ppc64
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_ppc64le.go
+++ b/bolt_ppc64le.go
@@ -1,9 +1,0 @@
-//go:build ppc64le
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_riscv64.go
+++ b/bolt_riscv64.go
@@ -1,9 +1,0 @@
-//go:build riscv64
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_s390x.go
+++ b/bolt_s390x.go
@@ -1,9 +1,0 @@
-//go:build s390x
-
-package bbolt
-
-// maxMapSize represents the largest mmap size supported by Bolt.
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB
-
-// maxAllocSize is the size used when creating array pointers.
-const maxAllocSize = 0x7FFFFFFF

--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"go.etcd.io/bbolt/errors"
+	"go.etcd.io/bbolt/internal/common"
 )
 
 // flock acquires an advisory lock on a file descriptor.
@@ -67,7 +68,7 @@ func mmap(db *DB, sz int) error {
 
 	// Save the original byte slice and convert to a byte array pointer.
 	db.dataref = b
-	db.data = (*[maxMapSize]byte)(unsafe.Pointer(&b[0]))
+	db.data = (*[common.MaxMapSize]byte)(unsafe.Pointer(&b[0]))
 	db.datasz = sz
 	return nil
 }

--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sys/windows"
 
 	"go.etcd.io/bbolt/errors"
+	"go.etcd.io/bbolt/internal/common"
 )
 
 // fdatasync flushes written data to a file descriptor.
@@ -95,7 +96,7 @@ func mmap(db *DB, sz int) error {
 	}
 
 	// Convert to a byte array.
-	db.data = (*[maxMapSize]byte)(unsafe.Pointer(addr))
+	db.data = (*[common.MaxMapSize]byte)(unsafe.Pointer(addr))
 	db.datasz = sz
 
 	return nil

--- a/db.go
+++ b/db.go
@@ -125,7 +125,7 @@ type DB struct {
 	// always fails on Windows platform.
 	//nolint
 	dataref  []byte // mmap'ed readonly, write throws SEGV
-	data     *[maxMapSize]byte
+	data     *[common.MaxMapSize]byte
 	datasz   int
 	meta0    *common.Meta
 	meta1    *common.Meta
@@ -563,7 +563,7 @@ func (db *DB) mmapSize(size int) (int, error) {
 	}
 
 	// Verify the requested size is not above the maximum allowed.
-	if size > maxMapSize {
+	if size > common.MaxMapSize {
 		return 0, errors.New("mmap too large")
 	}
 
@@ -581,8 +581,8 @@ func (db *DB) mmapSize(size int) (int, error) {
 	}
 
 	// If we've exceeded the max size then only grow up to the max size.
-	if sz > maxMapSize {
-		sz = maxMapSize
+	if sz > common.MaxMapSize {
+		sz = common.MaxMapSize
 	}
 
 	return int(sz), nil

--- a/db_test.go
+++ b/db_test.go
@@ -1373,6 +1373,27 @@ func TestDBUnmap(t *testing.T) {
 	db.DB = nil
 }
 
+func TestDB_HugeValue(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "db")
+	db, err := bolt.Open(dbPath, 0600, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	data := make([]byte, 0xFFFFFFF+1)
+
+	_ = db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("data"))
+		require.NoError(t, err)
+
+		err = b.Put([]byte("key"), data)
+		require.NoError(t, err)
+
+		return nil
+	})
+}
+
 func ExampleDB_Update() {
 	// Open the database.
 	db, err := bolt.Open(tempfile(), 0600, nil)

--- a/internal/common/bolt_386.go
+++ b/internal/common/bolt_386.go
@@ -1,0 +1,7 @@
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0x7FFFFFFF // 2GB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0xFFFFFFF

--- a/internal/common/bolt_amd64.go
+++ b/internal/common/bolt_amd64.go
@@ -1,0 +1,7 @@
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/bolt_arm.go
+++ b/internal/common/bolt_arm.go
@@ -1,0 +1,7 @@
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0x7FFFFFFF // 2GB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0xFFFFFFF

--- a/internal/common/bolt_arm64.go
+++ b/internal/common/bolt_arm64.go
@@ -1,0 +1,9 @@
+//go:build arm64
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/bolt_loong64.go
+++ b/internal/common/bolt_loong64.go
@@ -1,0 +1,9 @@
+//go:build loong64
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/bolt_mips64x.go
+++ b/internal/common/bolt_mips64x.go
@@ -1,0 +1,9 @@
+//go:build mips64 || mips64le
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0x8000000000 // 512GB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/bolt_mipsx.go
+++ b/internal/common/bolt_mipsx.go
@@ -1,0 +1,9 @@
+//go:build mips || mipsle
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0x40000000 // 1GB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0xFFFFFFF

--- a/internal/common/bolt_ppc.go
+++ b/internal/common/bolt_ppc.go
@@ -1,0 +1,9 @@
+//go:build ppc
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0x7FFFFFFF // 2GB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0xFFFFFFF

--- a/internal/common/bolt_ppc64.go
+++ b/internal/common/bolt_ppc64.go
@@ -1,0 +1,9 @@
+//go:build ppc64
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/bolt_ppc64le.go
+++ b/internal/common/bolt_ppc64le.go
@@ -1,0 +1,9 @@
+//go:build ppc64le
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/bolt_riscv64.go
+++ b/internal/common/bolt_riscv64.go
@@ -1,0 +1,9 @@
+//go:build riscv64
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/bolt_s390x.go
+++ b/internal/common/bolt_s390x.go
@@ -1,0 +1,9 @@
+//go:build s390x
+
+package common
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0xFFFFFFFFFFFF // 256TB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0x7FFFFFFF

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -17,9 +17,6 @@ const Magic uint32 = 0xED0CDAED
 
 const PgidNoFreelist Pgid = 0xffffffffffffffff
 
-// DO NOT EDIT. Copied from the "bolt" package.
-const pageMaxAllocSize = 0xFFFFFFF
-
 // IgnoreNoSync specifies whether the NoSync field of a DB is ignored when
 // syncing changes to a file.  This is required as some operating systems,
 // such as OpenBSD, do not have a unified buffer cache (UBC) and writes

--- a/internal/common/unsafe.go
+++ b/internal/common/unsafe.go
@@ -23,5 +23,5 @@ func UnsafeByteSlice(base unsafe.Pointer, offset uintptr, i, j int) []byte {
 	// index 0.  However, the wiki never says that the address must be to
 	// the beginning of a C allocation (or even that malloc was used at
 	// all), so this is believed to be correct.
-	return (*[pageMaxAllocSize]byte)(UnsafeAdd(base, offset))[i:j:j]
+	return (*[MaxAllocSize]byte)(UnsafeAdd(base, offset))[i:j:j]
 }

--- a/tx.go
+++ b/tx.go
@@ -495,8 +495,8 @@ func (tx *Tx) write() error {
 		// Write out page in "max allocation" sized chunks.
 		for {
 			sz := rem
-			if sz > maxAllocSize-1 {
-				sz = maxAllocSize - 1
+			if sz > common.MaxAllocSize-1 {
+				sz = common.MaxAllocSize - 1
 			}
 			buf := common.UnsafeByteSlice(unsafe.Pointer(p), written, 0, int(sz))
 


### PR DESCRIPTION
Backport https://github.com/etcd-io/bbolt/pull/968 to release-1.4 to fix https://github.com/etcd-io/bbolt/issues/931

cc @Elbehery @fuweid @ivanvc @tjungblu 