### PR TITLE
release: Switch branch to stable branch from script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,51 +19,69 @@ function get_gpg_key {
 }
 
 # === Main Script Logic ===
-echo "enter release string according to semantic versioning (e.g. v1.2.3)."
-read -r INPUT
-if [[ ! "${INPUT}" =~ ^v[0-9]+.[0-9]+.[0-9]+ ]]; then
-  echo "Expected 'version' param of the form 'v<major-version>.<minor-version>.<patch-version>' but got '${INPUT}'"
-  exit 1
-fi
+function main {
+  echo "enter release string according to semantic versioning (e.g. v1.2.3)."
+  read -r INPUT
+  if [[ ! "${INPUT}" =~ ^v[0-9]+.[0-9]+.[0-9]+ ]]; then
+    echo "Expected 'version' param of the form 'v<major-version>.<minor-version>.<patch-version>' but got '${INPUT}'"
+    exit 1
+  fi
 
-VERSION=${INPUT#v}
-RELEASE_VERSION="${VERSION}"
-MINOR_VERSION=$(echo "${VERSION}" | cut -d. -f 1-2)
+  VERSION=${INPUT#v}
+  RELEASE_VERSION="${VERSION}"
+  MINOR_VERSION=$(echo "${VERSION}" | cut -d. -f 1-2)
+  RELEASE_BRANCH="release-${MINOR_VERSION}"
 
-REPOSITORY=${REPOSITORY:-"git@github.com:etcd-io/bbolt.git"}
-REMOTE="${REMOTE:-"origin"}"
+  REPOSITORY=${REPOSITORY:-"git@github.com:etcd-io/bbolt.git"}
+  REMOTE="${REMOTE:-"origin"}"
 
-remote_tag_exists=$(git ls-remote --tags "${REPOSITORY}" | grep -c "${INPUT}" || true)
-if [ "${remote_tag_exists}" -gt 0 ]; then
-   echo "Release version tag exists on remote."
-   exit 1
-fi
+  remote_tag_exists=$(git ls-remote --tags "${REPOSITORY}" | grep -c "${INPUT}" || true)
+  if [ "${remote_tag_exists}" -gt 0 ]; then
+    echo "Release version tag exists on remote."
+    exit 1
+  fi
 
-# ensuring the minor-version is identical.
-source_version=$(grep -E "\s+Version\s*=" ./version/version.go | sed -e "s/.*\"\(.*\)\".*/\1/g")
-if [[ "${source_version}" != "${RELEASE_VERSION}" ]]; then
-   source_minor_version=$(echo "${source_version}" | cut -d. -f 1-2)
-   if [[ "${source_minor_version}" != "${MINOR_VERSION}" ]]; then
-     echo "Wrong bbolt minor version in version.go. Expected ${MINOR_VERSION} but got ${source_minor_version}. Aborting."
-     exit 1
-   fi
-fi
+  # Set up release directory.
+  local reldir="/tmp/bbolt-release-${VERSION}"
+  echo "Preparing temporary directory: ${reldir}"
+  if [ ! -d "${reldir}/bbolt" ]; then
+    mkdir -p "${reldir}"
+    cd "${reldir}"
+    git clone "${REPOSITORY}" --branch "${RELEASE_BRANCH}" --depth 1
+  fi
+  cd "${reldir}/bbolt" || exit 2
+  git checkout "${RELEASE_BRANCH}" || exit 2
+  git fetch origin
+  git reset --hard "origin/${RELEASE_BRANCH}"
 
-# bump 'version.go'.
-echo "Updating version from '${source_version}' to '${RELEASE_VERSION}' in 'version.go'"
-sed -i "s/${source_version}/${RELEASE_VERSION}/g" ./version/version.go
+  # ensuring the minor-version is identical.
+  source_version=$(grep -E "\s+Version\s*=" ./version/version.go | sed -e "s/.*\"\(.*\)\".*/\1/g")
+  if [[ "${source_version}" != "${RELEASE_VERSION}" ]]; then
+     source_minor_version=$(echo "${source_version}" | cut -d. -f 1-2)
+     if [[ "${source_minor_version}" != "${MINOR_VERSION}" ]]; then
+       echo "Wrong bbolt minor version in version.go. Expected ${MINOR_VERSION} but got ${source_minor_version}. Aborting."
+       exit 1
+     fi
+  fi
 
-# push 'version.go' to remote.
-echo "committing 'version.go'"
-git add ./version/version.go
-git commit -s -m "Update version to ${VERSION}"
-git push "${REMOTE}" "${INPUT}"
-echo "'version.go' has been committed to remote repo."
+  # bump 'version.go'.
+  echo "Updating version from '${source_version}' to '${RELEASE_VERSION}' in 'version.go'"
+  sed -i "s/${source_version}/${RELEASE_VERSION}/g" ./version/version.go
 
-# create tag and push to remote.
-echo "Creating new tag for '${INPUT}'"
-key_id=$(get_gpg_key) || return 2
-git tag --local-user "${key_id}" --sign "${INPUT}" --message "${INPUT}"
-git push "${REMOTE}" "${INPUT}"
-echo "Tag '${INPUT}' has been created and pushed to remote repo."
-echo "SUCCESS"
+  # push 'version.go' to remote.
+  echo "committing 'version.go'"
+  git add ./version/version.go
+  git commit -s -m "Update version to ${VERSION}"
+  git push origin "${RELEASE_BRANCH}"
+  echo "'version.go' has been committed to remote repo."
+
+  # create tag and push to remote.
+  echo "Creating new tag for '${INPUT}'"
+  key_id=$(get_gpg_key) || return 2
+  git tag --local-user "${key_id}" --sign "${INPUT}" --message "${INPUT}"
+  git push origin "${INPUT}"
+  echo "Tag '${INPUT}' has been created and pushed to remote repo."
+  echo "SUCCESS"
+}
+
+main

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,9 +36,9 @@ function main {
   RELEASE_BRANCH="release-${MINOR_VERSION}"
 
   REPOSITORY=${REPOSITORY:-"git@github.com:etcd-io/bbolt.git"}
-  REMOTE="${REMOTE:-"origin"}"
 
-  remote_tag_exists=$(git ls-remote --tags "${REPOSITORY}" | grep -c "${VERSION}" || true)
+  local remote_tag_exists
+  remote_tag_exists=$(git ls-remote "${REPOSITORY}" "refs/tags/${VERSION}" | grep -c "${VERSION}" || true)
   if [ "${remote_tag_exists}" -gt 0 ]; then
     echo "Release version tag exists on remote."
     exit 1


### PR DESCRIPTION
Follow up from https://github.com/etcd-io/bbolt/pull/903#discussion_r2137818287

Switch branches to avoid backporting and maintaining the release script in each of the stable release branches.

/cc @ahrtr @Elbehery 