### PR TITLE
Run ARM64 test workflow on Ubuntu ARM

### DIFF
--- a/.github/workflows/tests_arm64.yaml
+++ b/.github/workflows/tests_arm64.yaml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   test-linux-arm64:
     uses: ./.github/workflows/tests-template.yml
+    with:
+      runs-on: ubuntu-24.04-arm
   test-linux-arm64-race:
     uses: ./.github/workflows/tests-template.yml
     with:


### PR DESCRIPTION
As I was about to start working on https://github.com/etcd-io/bbolt/pull/977#discussion_r2140071160, I realized that our ARM64 workflow had this issue.

The test ARM64 workflow was running on a regular Ubuntu machine. Specify the ARM suffix to ensure that the tests run on the ARM architecture.