### PR TITLE
tx: add missing lock on meta page update

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -561,10 +561,13 @@ func (tx *Tx) writeMeta() error {
 	tx.meta.Write(p)
 
 	// Write the meta page to file.
+	tx.db.metalock.Lock()
 	if _, err := tx.db.ops.writeAt(buf, int64(p.Id())*int64(tx.db.pageSize)); err != nil {
+		tx.db.metalock.Unlock()
 		lg.Errorf("writeAt failed, pgid: %d, pageSize: %d, error: %v", p.Id(), tx.db.pageSize, err)
 		return err
 	}
+	tx.db.metalock.Unlock()
 	if !tx.db.NoSync || common.IgnoreNoSync {
 		// gofail: var beforeSyncMetaPage struct{}
 		if err := fdatasync(tx.db); err != nil {


### PR DESCRIPTION
Let's discuss this part of #967 (not related to the original problem in fact). But it can affect ed58abdb0a684117422dec68021324507db0224c rework, a better version of it is still in progress.

metalock is supposed to protect meta page, but it looks like the only place where we're modifying it is not protected in fact. Since page update is not atomic a concurrent reader (like transaction) can get an inconsistent page. It's likely to fall back to the other one in this case, but still we better not allow this to happen.