### PR TITLE
Update changelog for 1.4.2 and 1.5.0

### DIFF
--- a/CHANGELOG/CHANGELOG-1.4.md
+++ b/CHANGELOG/CHANGELOG-1.4.md
@@ -1,6 +1,13 @@
 
 <hr>
 
+## v1.4.2(TBD)
+
+### BoltDB
+- [Fix the compilation issue on aix, android and solaris due to wrong use of `maxMapSize`](https://github.com/etcd-io/bbolt/pull/990)
+
+<hr>
+
 ## v1.4.1(2025-06-10)
 
 ### BoltDB

--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -1,0 +1,10 @@
+<hr>
+
+## v1.5.0(TBD)
+
+### BoltDB
+- [Add support for data file size limit](https://github.com/etcd-io/bbolt/pull/929)
+- [Remove the unused txs list](https://github.com/etcd-io/bbolt/pull/973)
+- [Add option `NoStatistics` to make the statistics optional](https://github.com/etcd-io/bbolt/pull/977)
+
+<hr>


### PR DESCRIPTION
cc @Elbehery @fuweid @ivanvc @tjungblu 

We add CHANGELOG-1.5 for now. If we decide to release 2.0 in future, we can change it by then.