### PR TITLE
db: rework metalock into RWMutex

### DIFF
--- a/internal/freelist/freelist.go
+++ b/internal/freelist/freelist.go
@@ -22,6 +22,9 @@ type Interface interface {
 	// Init initializes this freelist with the given list of pages.
 	Init(ids common.Pgids)
 
+	// AddCurrentTXID adds the latest known ID to the list.
+	AddCurrentTXID(tid common.Txid)
+
 	// Allocate tries to allocate the given number of contiguous pages
 	// from the free list pages. It returns the starting page ID if
 	// available; otherwise, it returns 0.

--- a/tx.go
+++ b/tx.go
@@ -569,6 +569,7 @@ func (tx *Tx) writeMeta() error {
 		lg.Errorf("writeAt failed, pgid: %d, pageSize: %d, error: %v", p.Id(), tx.db.pageSize, err)
 		return err
 	}
+	tx.db.freelist.AddCurrentTXID(tx.meta.Txid())
 	tx.db.metalock.Unlock()
 	if !tx.db.NoSync || common.IgnoreNoSync {
 		// gofail: var beforeSyncMetaPage struct{}


### PR DESCRIPTION
### Background
See #967 for motivation and test used. This is the version 2.5 of the patch, it differs significantly from the one presented in #967. The original version worked well in production, but:
 * it had a known (mentioned in commit message) minor issue with DBs that just started and had no RW transactions
 * it had a race with `db.freelist` access between reader threads and `db.close()`
 * it was discovered later that it also is incompatible with `NoFreelistSync` option
 * it added new locks

So version 2 was created in 0a70458e170481a15a900f79f42b2a7e81923898 that was relying on the old locks only which I think makes it much simpler, but it had to extend freelist API a little. Turned out, this version was flawed even though it was all green on tests. In production it failed to release pages correctly leading to DB bloat and total disaster. Luckily, it wasn't hard to fix and now we have version 2.5 which is presented here. It passes all tests and also has been tested on real DBs, so it should be OK to use. Still, it's the most complex change from #967 series, so please review carefully.

### Change itself
metalock is documented to protect meta page access, but its real functionality is broader and less obvious:
 * meta page itself is accessed in t.init(), but it's not changed, so an exclusive lock is not needed
 * db.opened is somewhat related, but it's changed in close() only which takes all the locks anyway
 * db.data is used close to this lock, but it's protected by mmaplock
 * db.freelist is in fact changed when metalock is taken and it has no synchronization of its own (notice that db.freelist pointer is changed in close() as well, so some synchronization is needed for it also)

So we have a lock that tries to protect meta page (and does it after 249746fef43a12e0b5368d98006be51d3afa4d3a), but in fact it helps freelists more than the others. What we're trying to do in freelist is to keep track of open RO transaction IDs, maintaining a slice of them. Transaction IDs in their turn are not exactly IDs in that they do not identify transactions uniquely, rather it's an ID of the latest transaction that changed the state and at any given point all of the new readers use the same latest ID. The other important aspect of these IDs is that any RW transaction always uses a new ID that is incremented from the previous one, IDs only move forward (not considering uint64 overflow). At the very minimum this means that:
 * the most common case is when this list has exactly one unique ID which is the latest
 * occasionally we can have a previous one as well
 * only in rare cases of long-running read transactions we can have some set of older IDs
 * once an old ID is gone it'll never return since new transactions use the latest one

Which in turn means that:
 * keeping a list of IDs wastes memory for nothing, we usually have a lot of duplicates there
 * what we need in fact is some sort of reference counting for a limited number of past IDs
 * no new IDs are possible unless there is an RW transaction

Reference counting can be implemented with atomic variables, not requiring locks, the only problem is to always have an appropriate ID to count its users. This can be done via a separate RW-transaction-only API managing a list of ID-ref structures. It requires some protection from readers, but this can be tied to meta page update since RO transactions can't use new ID earlier than it appears there. Then RO transactions can rely on this list always having current ID that they can use, which means they can use RO lock for the list itself while doing changes to the counter.

This removes the final exclusive lock for read-only transactions (with disabled statistics) and this drastically improves concurrent View() test results as well as real application behavior with many readers. Before:
```
workers samples min             avg             50%             80%             90%             max
1       10      78.358µs        964.847µs       1.059159ms      1.073256ms      1.07551ms       1.07551ms
10      100     32.802µs        304.922µs       80.924µs        674.54µs        1.069298ms      1.220625ms
100     1000    30.758µs        304.541µs       64.192µs        397.094µs       1.101991ms      2.183302ms
1000    10000   30.558µs        1.05711ms       92.426µs        2.111896ms      3.317894ms      11.790014ms
10000   100000  30.548µs        10.98898ms      90.742µs        21.740659ms     33.020076ms     135.33094ms
```
After:
```
workers samples min             avg             50%             80%             90%             max
1       10      96.093µs        969.267µs       1.063618ms      1.066473ms      1.085629ms      1.085629ms
10      100     32.803µs        252.33µs        73.71µs         827.159µs       934.392µs       1.071142ms
100     1000    31.339µs        239.554µs       38.703µs        613.263µs       888.616µs       1.403793ms
1000    10000   30.518µs        195.822µs       41.538µs        101.031µs       360.474µs       4.075932ms
10000   100000  30.478µs        165.346µs       39.054µs        89.981µs        144.544µs       11.35032ms
```