### PR TITLE
Add template to cross arch build tests

### DIFF
--- a/.github/workflows/cross-arch-template.yaml
+++ b/.github/workflows/cross-arch-template.yaml
@@ -1,0 +1,29 @@
+---
+name: Reusable Cross-Platform Build Workflow
+on:
+  workflow_call:
+    inputs:
+      archs:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+permissions: read-all
+
+jobs:
+  cross-build:
+    strategy:
+      matrix:
+        arch: ${{ fromJSON(inputs.archs) }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - id: goversion
+      run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+    - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        go-version: ${{ steps.goversion.outputs.goversion }}
+    - name: Build for ${{ inputs.os }}/${{ matrix.arch }}
+      run: |
+        GOOS=${{ inputs.os }} GOARCH=${{ matrix.arch }} go build ./...

--- a/.github/workflows/cross-arch-test.yaml
+++ b/.github/workflows/cross-arch-test.yaml
@@ -1,135 +1,36 @@
 ---
 name: Cross-Platform Build Tests
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+permissions: read-all
+on: [push, pull_request]
 
 jobs:
   build-aix:
-    strategy:
-      matrix:
-        goarch: [ppc64]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6          
-
-      - name: Build for aix/${{ matrix.goarch }}
-        run: |
-          GOOS=aix GOARCH=${{ matrix.GOARCH }} go build ./...
-
+    uses: ./.github/workflows/cross-arch-template.yaml
+    with:
+      os: aix
+      archs: "['ppc64']"
   build-android:
-    strategy:
-      matrix:
-        goarch: [arm64]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6          
-
-      - name: Build for android/${{ matrix.goarch }}
-        run: |
-          GOOS=android GOARCH=${{ matrix.goarch }} go build ./...
-
+    uses: ./.github/workflows/cross-arch-template.yaml
+    with:
+      os: android
+      archs: "['arm64']"
   build-linux:
-    strategy:
-      matrix:
-        goarch: [386, amd64, arm, arm64, loong64, mips, mips64, mips64le, mipsle, ppc64, ppc64le, riscv64, s390x]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6          
-
-      - name: Build for linux/${{ matrix.goarch }}
-        run: |
-          GOOS=linux GOARCH=${{ matrix.GOARCH }} go build ./...
-
+    uses: ./.github/workflows/cross-arch-template.yaml
+    with:
+      os: linux
+      archs: "['386','amd64','arm','arm64','loong64','mips','mips64','mips64le','mipsle','ppc64','ppc64le','riscv64','s390x']"
   build-openbsd:
-    strategy:
-      matrix:
-        goarch: [386, amd64, arm, arm64, ppc64, riscv64]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6          
-
-      - name: Build for openbsd/${{ matrix.goarch }}
-        run: |
-          GOOS=openbsd GOARCH=${{ matrix.GOARCH }} go build ./...  
-
+    uses: ./.github/workflows/cross-arch-template.yaml
+    with:
+      os: openbsd
+      archs: "['386','amd64','arm','arm64','ppc64','riscv64']"
   build-solaris:
-    strategy:
-      matrix:
-        goarch: [amd64]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6          
-
-      - name: Build for solaris/${{ matrix.goarch }}
-        run: |
-          GOOS=solaris GOARCH=${{ matrix.GOARCH }} go build ./...
-
+    uses: ./.github/workflows/cross-arch-template.yaml
+    with:
+      os: solaris
+      archs: "['amd64']"
   build-windows:
-    strategy:
-      matrix:
-        goarch: [386, amd64, arm64]
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - id: goversion
-        run: echo "goversion=$(cat .go-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: ${{ steps.goversion.outputs.goversion }}
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6          
-
-      - name: Build for windows/${{ matrix.goarch }}
-        run: |
-          $env:GOOS="windows"; $env:GOARCH="${{ matrix.GOARCH }}"; go build ./...
+    uses: ./.github/workflows/cross-arch-template.yaml
+    with:
+      os: windows
+      archs: "['386','amd64','arm64']"


### PR DESCRIPTION
* Create a template to simplify executing tests without repetition.
* Run cross-compilation tests for Windows on Ubuntu (Linux), as every platform is being cross-compiled as a sanity check, it could also be done using Linux, and simplify the template.
* Remove the GolangCI lint action, as it is linting in Linux (as this is not using QEMU, but only cross-compilation), and there's no benefit to adding this step, as it's already checked in other workflows.

Follow up on #986.