### PR TITLE
Protect meta page when it's being written

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -569,14 +569,15 @@ func (tx *Tx) writeMeta() error {
 		lg.Errorf("writeAt failed, pgid: %d, pageSize: %d, error: %v", p.Id(), tx.db.pageSize, err)
 		return err
 	}
-	tx.db.metalock.Unlock()
 	if !tx.db.NoSync || common.IgnoreNoSync {
 		// gofail: var beforeSyncMetaPage struct{}
 		if err := fdatasync(tx.db); err != nil {
+			tx.db.metalock.Unlock()
 			lg.Errorf("[GOOS: %s, GOARCH: %s] fdatasync failed: %w", runtime.GOOS, runtime.GOARCH, err)
 			return err
 		}
 	}
+	tx.db.metalock.Unlock()
 
 	// Update statistics.
 	tx.stats.IncWrite(1)


### PR DESCRIPTION
Followup to https://github.com/etcd-io/bbolt/pull/989

We should protect the `fdatasync` as well.


cc @roman-khimov @Elbehery @fuweid @tjungblu 