### PR TITLE
chore(test): bump_windows_test_timeout

### DIFF
--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           case "${TARGET}" in
             windows-amd64-unit-test-4-cpu)
-              CPU=4 make test
+              CPU=4 TIMEOUT=40m make test
               ;;
             *)
               echo "Failed to find target"
@@ -59,3 +59,5 @@ jobs:
         with:
           version: v2.1.6
       - run: make coverage
+        env:
+          TIMEOUT: 40m


### PR DESCRIPTION
This PR bumps test timeout in Windows environment to 40m.

See https://github.com/etcd-io/bbolt/pull/1030#discussion_r2213786622

cc @ahrtr @ivanvc 