### PR TITLE
[release-1.4]:chore(test): bump_windows_test_timeout

### DIFF
--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           case "${TARGET}" in
             windows-amd64-unit-test-4-cpu)
-              CPU=4 make test
+              CPU=4 TIMEOUT=50m make test
               ;;
             *)
               echo "Failed to find target"
@@ -55,3 +55,5 @@ jobs:
         with:
           go-version: ${{ steps.goversion.outputs.goversion }}
       - run: make coverage
+        env:
+          TIMEOUT: 50m


### PR DESCRIPTION
Backport of https://github.com/etcd-io/bbolt/pull/1032

see https://github.com/etcd-io/bbolt/pull/1049#issuecomment-3172726445

cc @ahrtr 