### PR TITLE
Add new project (listly) to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,7 @@ Below is a list of public, open source projects that use Bolt:
 * [Kala](https://github.com/ajvb/kala) - Kala is a modern job scheduler optimized to run on a single node. It is persistent, JSON over HTTP API, ISO 8601 duration notation, and dependent jobs.
 * [Key Value Access Language (KVAL)](https://github.com/kval-access-language) - A proposed grammar for key-value datastores offering a bbolt binding.
 * [LedisDB](https://github.com/siddontang/ledisdb) - A high performance NoSQL, using Bolt as optional storage.
+* [listly](https://github.com/JLZ22/listly) - CLI utility with a fully interactive terminal UI for managing and editing todo lists using Bolt to persist data across sessions.
 * [lru](https://github.com/crowdriff/lru) - Easy to use Bolt-backed Least-Recently-Used (LRU) read-through cache with chainable remote stores.
 * [mbuckets](https://github.com/abhigupta912/mbuckets) - A Bolt wrapper that allows easy operations on multi level (nested) buckets.
 * [MetricBase](https://github.com/msiebuhr/MetricBase) - Single-binary version of Graphite.


### PR DESCRIPTION
I just finished up a personal project using Bolt for persistent storage across runs. My project, `listly`, is a todo-list manager and editor that uses Bolt for persistent storage across runs. Below are two demos. 

![demo](https://github.com/user-attachments/assets/d04401f4-2088-4531-a13e-1a0c3b83665b)
[Slightly Longer YouTube Demo](https://youtu.be/s1b4MqS0Fhg)