### PR TITLE
internal/common: added PgidSet to replace usages of map[Pgid]bool

### DIFF
--- a/db.go
+++ b/db.go
@@ -1251,7 +1251,7 @@ func (db *DB) freepages() []common.Pgid {
 	}
 
 	reachable := make(map[common.Pgid]*common.Page)
-	nofreed := make(map[common.Pgid]bool)
+	nofreed := make(common.PgidSet)
 	ech := make(chan error)
 	go func() {
 		for e := range ech {

--- a/internal/common/page.go
+++ b/internal/common/page.go
@@ -389,3 +389,23 @@ func Mergepgids(dst, a, b Pgids) {
 	// Append what's left in follow.
 	_ = append(merged, follow...)
 }
+
+type PgidSet map[Pgid]struct{}
+
+func (s *PgidSet) Add(key Pgid) {
+	if *s == nil {
+		*s = make(map[Pgid]struct{})
+	}
+
+	(*s)[key] = struct{}{}
+}
+
+func (s *PgidSet) Has(key Pgid) bool {
+	if *s == nil {
+		return false
+	}
+
+	_, ok := (*s)[key]
+
+	return ok
+}

--- a/internal/common/page_test.go
+++ b/internal/common/page_test.go
@@ -70,3 +70,43 @@ func TestPgids_merge_quick(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestPgidSet_initialization(t *testing.T) {
+	var s PgidSet
+	if s != nil {
+		t.Fatal("Set must be nil")
+	}
+
+	s.Add(0)
+	if s == nil {
+		t.Fatal("Set must be initialized")
+	}
+}
+
+func TestPgidSet_set_has_added_values(t *testing.T) {
+	var s PgidSet
+	s.Add(100)
+	if len(s) != 1 || !s.Has(100) {
+		t.Fatal("Set must contain exactly one element")
+	}
+
+	s.Add(200)
+	if len(s) != 2 || !s.Has(200) {
+		t.Fatal("Set must contain exactly two elements")
+	}
+}
+
+func TestPgidSet_duplicates(t *testing.T) {
+	var s PgidSet
+	s.Add(5)
+	s.Add(5)
+	if len(s) != 1 {
+		t.Fatal("Set must still contain exactly one element after adding duplicate")
+	}
+
+	s.Add(15)
+	s.Add(15)
+	if len(s) != 2 {
+		t.Fatal("Set must still contain exactly two elements after adding duplicate")
+	}
+}

--- a/internal/freelist/shared.go
+++ b/internal/freelist/shared.go
@@ -220,10 +220,10 @@ func (t *shared) Reload(p *common.Page) {
 
 func (t *shared) NoSyncReload(pgIds common.Pgids) {
 	// Build a cache of only pending pages.
-	pcache := make(map[common.Pgid]struct{})
+	pcache := make(common.PgidSet)
 	for _, txp := range t.pending {
 		for _, pendingID := range txp.ids {
-			pcache[pendingID] = struct{}{}
+			pcache.Add(pendingID)
 		}
 	}
 
@@ -231,7 +231,7 @@ func (t *shared) NoSyncReload(pgIds common.Pgids) {
 	// with any pages not in the pending lists.
 	a := []common.Pgid{}
 	for _, id := range pgIds {
-		if _, ok := pcache[id]; !ok {
+		if !pcache.Has(id) {
 			a = append(a, id)
 		}
 	}


### PR DESCRIPTION
As a followup  of the work carried out in [#1082](https://github.com/etcd-io/bbolt/pull/1082).

In the `freelist` package I found `pidSet` that, if extended to have `Add`, `Has`, `Remove` methods and made public, can replace all usages of `map[Pgid]bool` and `map[Pgid]struct{}`
Let me know if this new `PgidSet` type looks good to you or if you prefer to stick to using `map[string]struct{}` instead.
