### PR TITLE
Streamline `os.Exit` calls in main.go

### DIFF
--- a/cmd/bbolt/main.go
+++ b/cmd/bbolt/main.go
@@ -12,9 +12,7 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		if rootCmd.SilenceErrors {
 			fmt.Fprintln(os.Stderr, "Error:", err)
-			os.Exit(1)
-		} else {
-			os.Exit(1)
 		}
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Changes:
This PR simplifies the error-handling logic in `main` by removing a redundant conditional and using a single call to `os.Exit(1)`.