### PR TITLE
[db] move panic handling from goroutine to the parent function

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -6,5 +6,6 @@
 - [Add support for data file size limit](https://github.com/etcd-io/bbolt/pull/929)
 - [Remove the unused txs list](https://github.com/etcd-io/bbolt/pull/973)
 - [Add option `NoStatistics` to make the statistics optional](https://github.com/etcd-io/bbolt/pull/977)
+- [Move panic handling from goroutine to the parent function](https://github.com/etcd-io/bbolt/pull/1153)
 
 <hr>


### PR DESCRIPTION
### What does this PR do?

Previously, we listened on `ech` inside a goroutine and triggered a panic if an error was received. Since the panic occurred within the goroutine, it cannot be recovered by the parent function by design.

This PR changes the flow as follows:
1. Call `recursivelyCheckBucket` in a goroutine
2. Wait for any errors in the parent function and panic, if any error was received.

This way, the panic happens outside the goroutine and can be recovered.

### Testing

Tested following program with a corrupted DB file and `recover()` works as expected
 
```go
package main

import (
	"fmt"

	"go.etcd.io/bbolt"
)

func main() {
	defer func() {
		if r := recover(); r != nil {
			fmt.Println("Recovered from:", r)
		}
	}()

	db, _ := bbolt.Open("PATH_TO_DB", 0666, bbolt.DefaultOptions)
	defer db.Close()
}
```
[receiver_filelog_.tgz](https://github.com/user-attachments/files/25540806/receiver_filelog_.tgz)


### Issues

Closes https://github.com/etcd-io/bbolt/issues/1011