### PR TITLE
feature: Add Options.NoLock to skip advisory lock for read-only opens

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -27,6 +27,10 @@ var (
 	// ErrTimeout is returned when a database cannot obtain an exclusive lock
 	// on the data file after the timeout passed to Open().
 	ErrTimeout = errors.New("timeout")
+
+	// ErrNoLockRequiresReadOnly is returned when Options.NoLock is set without
+	// also setting Options.ReadOnly.
+	ErrNoLockRequiresReadOnly = errors.New("NoLock requires ReadOnly to be set")
 )
 
 // These errors can occur when beginning or committing a Tx.


### PR DESCRIPTION
## Problem

In environments where a bbolt database is shared across container boundaries (e.g. two Kubernetes pods mounting the same PersistentVolume), a `ReadOnly` open blocks indefinitely waiting to acquire a shared lock (`LOCK_SH`) while the primary process holds an exclusive lock (`LOCK_EX`). This makes it impossible to perform a live read from a sidecar or job pod without stopping the primary process first.

## Solution

Add `NoLock bool` to `Options`. When set, the advisory file lock is skipped entirely on open. The option is only valid when `ReadOnly` is also set. `Open` returns `ErrNoLockRequiresReadOnly` otherwise.

## Safety

Allowing `NoLock` without `ReadOnly` would be unsafe, since the file lock is the only mechanism preventing concurrent writers from corrupting the database. Requiring `ReadOnly` provides two layers of enforcement:

- The OS opens the file `O_RDONLY`, making writes impossible at the syscall level.
- bbolt returns `ErrDatabaseReadOnly` from `Begin(true)`, `Update()`, and `Batch()`.

Concurrent reads are safe regardless of lock state because bbolt uses copy-on-write page allocation. Existing pages are never modified in place, and a read transaction operates on a consistent snapshot based on the meta page at the time the transaction opens.

## Changes

- `errors/errors.go`: new `ErrNoLockRequiresReadOnly` error
- `db.go`: `NoLock bool` field in `Options`, validation in `Open()`, flock skip with info log, `NoLock` included in `Options.String()`
- `db_test.go`: three tests covering the error case, normal read-only behavior, and successful open while a writer holds the exclusive lock