### PR TITLE
[release-1.3] Bump golangcilint to v2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,10 +46,10 @@ jobs:
             exit 1
             ;;
         esac
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v1.64.8
+        version: v2.10.1
 
   test-windows:
     strategy:
@@ -87,10 +87,10 @@ jobs:
             ;;
         esac
       shell: bash
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v1.64.8
+        version: v2.10.1
 
   coverage:
     needs: ["test-linux", "test-windows"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -87,10 +87,6 @@ jobs:
             ;;
         esac
       shell: bash
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-      with:
-        version: v2.10.1
 
   coverage:
     needs: ["test-linux", "test-windows"]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,34 @@
+formatters:
+  enable:
+    - gofmt
+issues:
+  max-same-issues: 0
+linters:
+  default: none
+  enable: # please keep this alphabetized
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+  settings: # please keep this alphabetized
+    staticcheck:
+      checks:
+        - all
+        - -QF1003 # Convert if/else-if chain to tagged switch
+        - -QF1004 # Use strings.ReplaceAll instead of strings.Replace with n == -1
+        - -QF1008 # Omit embedded fields from selector expression
+        - -QF1010 # Convert slice of bytes to string when printing it
+        - -QF1011 # Omit redundant type from variable declaration
+        - -ST1003 # Poorly chosen identifier
+        - -ST1005 # Incorrectly formatted error string
+        - -ST1006 # Poorly chosen receiver name
+        - -ST1012 # Poorly chosen name for error variable
+        - -ST1016 # Use consistent method receiver names
+version: "2"


### PR DESCRIPTION
Manual backport of #954 / 675a3be11525d7faba36ef81ab297a70a24ceb39.

Silence linters that fail with the current state of the code, as we don't want to change the stable release code.

Trying to unblock #1158 / The Go version bump (etcd-io/etcd#21458).