### PR TITLE
[release-1.4] Bump golangci-lint to v2

### DIFF
--- a/.github/workflows/tests-template.yml
+++ b/.github/workflows/tests-template.yml
@@ -51,7 +51,7 @@ jobs:
               exit 1
               ;;
           esac
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v1.64.8
+          version: v2.10.1

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -39,10 +39,6 @@ jobs:
               ;;
           esac
         shell: bash
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
-        with:
-          version: v2.10.1
 
   coverage:
     needs: ["test-windows"]

--- a/.github/workflows/tests_windows.yml
+++ b/.github/workflows/tests_windows.yml
@@ -39,10 +39,10 @@ jobs:
               ;;
           esac
         shell: bash
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v1.64.8
+          version: v2.10.1
 
   coverage:
     needs: ["test-windows"]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,39 @@
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings: # please keep this alphabetized
+    goimports:
+      local-prefixes:
+        - go.etcd.io # Put imports beginning with prefix after 3rd-party packages.
+issues:
+  max-same-issues: 0
+linters:
+  default: none
+  enable: # please keep this alphabetized
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+  settings: # please keep this alphabetized
+    staticcheck:
+      checks:
+        - all
+        - -QF1003 # Convert if/else-if chain to tagged switch
+        - -QF1004 # Use strings.ReplaceAll instead of strings.Replace with n == -1
+        - -QF1010 # Convert slice of bytes to string when printing it
+        - -QF1011 # Omit redundant type from variable declaration
+        - -ST1003 # Poorly chosen identifier
+        - -ST1005 # Incorrectly formatted error string
+        - -ST1006 # Poorly chosen receiver name
+        - -ST1012 # Poorly chosen name for error variable
+        - -ST1016 # Use consistent method receiver names
+        - -ST1023 # Redundant type in variable declaration
+version: "2"


### PR DESCRIPTION
Manual backport of etcd-io#954 / 675a3be.

Silence linters that fail with the current state of the code, as we don't want to change the stable release code.

Trying to unblock #1157 / The Go version bump (etcd-io/etcd#21458).