### PR TITLE
fix: Check command deadlocks on corrupted DB with page cycles

### DIFF
--- a/tx_check.go
+++ b/tx_check.go
@@ -90,6 +90,10 @@ func (tx *Tx) check(cfg checkConfig, ch chan error) {
 
 func (tx *Tx) recursivelyCheckPage(pageId common.Pgid, reachable map[common.Pgid]*common.Page, freed map[common.Pgid]bool,
 	kvStringer KVStringer, ch chan error) {
+	if _, already := reachable[pageId]; already {
+		ch <- fmt.Errorf("page %d: cycle detected (already reachable)", int(pageId))
+		return
+	}
 	tx.checkInvariantProperties(pageId, reachable, freed, kvStringer, ch)
 	tx.recursivelyCheckBucketInPage(pageId, reachable, freed, kvStringer, ch)
 }


### PR DESCRIPTION
### Summary

The `Check()` command deadlocks (infinite recursion) when the database has a corrupted page structure containing cycles — e.g., a branch page pointing to an ancestor.

### Root Cause

`recursivelyCheckPage()` traverses the page tree without any cycle detection. The `reachable` map exists but is only used after traversal for reporting unreachable/freed pages — it is never checked during traversal. A corrupted page pointing back to an ancestor causes unbounded recursion.

### Impact

This affects all etcd users running snapshot status/check on potentially corrupted databases. The `etcdctl snapshot status` command hangs forever, making recovery impossible.

### Fix

Check if the page ID is already in the `reachable` map before recursing. If it is, emit an error and return instead of recursing infinitely.

Fixes #877
