### PR TITLE
cmd/bbolt: reject overflowing page-item indexes

### DIFF
--- a/cmd/bbolt/command/command_page_item.go
+++ b/cmd/bbolt/command/command_page_item.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -52,6 +53,9 @@ func (o *pageItemOptions) AddFlags(fs *pflag.FlagSet) {
 func pageItemFunc(cmd *cobra.Command, cfg pageItemOptions, dbPath string, pageID, itemID uint64) (err error) {
 	if cfg.keyOnly && cfg.valueOnly {
 		return errors.New("the --key-only or --value-only flag may be set, but not both")
+	}
+	if itemID > math.MaxUint16 {
+		return fmt.Errorf("itemid must be less than or equal to %d, but got %d", math.MaxUint16, itemID)
 	}
 
 	if _, err := checkSourceDBPath(dbPath); err != nil {

--- a/cmd/bbolt/command/command_page_item_test.go
+++ b/cmd/bbolt/command/command_page_item_test.go
@@ -104,3 +104,40 @@ func TestPageItemCommand_NoArgs(t *testing.T) {
 	err := rootCmd.Execute()
 	require.ErrorContains(t, err, expErr.Error())
 }
+
+func TestPageItemCommand_ItemIDOverflow(t *testing.T) {
+	db := btesting.MustCreateDBWithOption(t, &bolt.Options{PageSize: 4096})
+	srcPath := db.Path()
+
+	err := db.Update(func(tx *bolt.Tx) error {
+		b, bErr := tx.CreateBucketIfNotExists([]byte("data"))
+		if bErr != nil {
+			return bErr
+		}
+		return b.Put([]byte("key_0"), []byte("value_0"))
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	defer requireDBNoChange(t, dbData(t, srcPath), srcPath)
+
+	meta := readMetaPage(t, srcPath)
+	leafPageID := 0
+	for i := 2; i < int(meta.Pgid()); i++ {
+		p, _, err := guts_cli.ReadPage(srcPath, uint64(i))
+		require.NoError(t, err)
+		if p.IsLeafPage() && p.Count() > 0 {
+			leafPageID = int(p.Id())
+		}
+	}
+	require.NotEqual(t, 0, leafPageID)
+
+	rootCmd := command.NewRootCommand()
+	outBuf := &bytes.Buffer{}
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetArgs([]string{"page-item", db.Path(), fmt.Sprintf("%d", leafPageID), "65536"})
+
+	err = rootCmd.Execute()
+	require.ErrorContains(t, err, "itemid")
+	require.NotContains(t, outBuf.String(), "key_0")
+	require.NotContains(t, outBuf.String(), "value_0")
+}


### PR DESCRIPTION
`page-item` takes itemid as uint64 but then casts it to uint16. So `65536` wraps to `0` and prints the first item. tiny CLI footgun, but pretty real.

Repro:
```sh
bbolt page-item test.db <leaf-page-id> 65536
```

Before: succeeds and prints item 0, kinda yikes.
After: returns an itemid range error before reading the page.

Added a regression test for the wraparound case.

Tests:
```sh
go test ./cmd/bbolt/command -count=1
go test $(go list ./... | rg -v '/tests/failpoint$')
```

`go test ./...` still hits local failpoint setup failures here (`failpoint: failpoint does not exist`), unrelated to this change.