### PR TITLE
fix: Prevent speculative file growth and mmap state on MaxSize exceeded on `Windows` env.

### DIFF
--- a/bolt_windows.go
+++ b/bolt_windows.go
@@ -68,19 +68,6 @@ func mmap(db *DB, sz int) error {
 	var sizelo, sizehi uint32
 
 	if !db.readOnly {
-		if db.MaxSize > 0 && sz > db.MaxSize {
-			// The max size only limits future writes; however, we don’t block opening
-			// and mapping the database if it already exceeds the limit.
-			fileSize, err := db.fileSize()
-			if err != nil {
-				return fmt.Errorf("could not check existing db file size: %s", err)
-			}
-
-			if sz > fileSize {
-				return errors.ErrMaxSizeReached
-			}
-		}
-
 		// Truncate the database to the size of the mmap.
 		if err := db.file.Truncate(int64(sz)); err != nil {
 			return fmt.Errorf("truncate: %s", err)

--- a/db.go
+++ b/db.go
@@ -476,6 +476,23 @@ func (db *DB) mmap(minsz int) (err error) {
 		return err
 	}
 
+	if db.MaxSize > 0 && size > db.MaxSize {
+		// On Windows, the data file is expanded to the full mapped size during mmap,
+		// so we must reject any mmap size larger than the configured max size.
+		//
+		// On other platforms, mmap itself does not grow the file immediately, so the
+		// mapped size may exceed the max size temporarily. The file size limit is
+		// enforced later when the file actually grows.
+		//
+		// In practice, this check mainly applies when opening a database with a large
+		// InitialMmapSize. In all other cases, file growth is already guarded during
+		// page allocation.
+		if size > fileSize && runtime.GOOS == "windows" {
+			db.Logger().Errorf("[GOOS: %s, GOARCH: %s] maximum db size reached, size: %d, db.MaxSize: %d", runtime.GOOS, runtime.GOARCH, size, db.MaxSize)
+			return berrors.ErrMaxSizeReached
+		}
+	}
+
 	if db.Mlock {
 		// Unlock db memory
 		if err := db.munlock(fileSize); err != nil {
@@ -1165,6 +1182,26 @@ func (db *DB) allocate(txid common.Txid, count int) (*common.Page, error) {
 	// Resize mmap() if we're at the end.
 	p.SetId(db.rwtx.meta.Pgid())
 	var minsz = int((p.Id()+common.Pgid(count))+1) * db.pageSize
+	if db.MaxSize > 0 {
+		nextAllocSize := minsz
+		nextMmapSize, err := db.mmapSize(minsz)
+		if err != nil {
+			return nil, fmt.Errorf("mmap size calculation error: %w", err)
+		}
+		if runtime.GOOS == "windows" {
+			// nextAllocSize may not exactly match nextMmapSize.
+			// On Windows, this mismatch may cause the file size to slightly exceed maxSize,
+			// while it is harmless on other platforms.
+			nextAllocSize = nextMmapSize
+		} else {
+			// On non-Windows platforms, the database file is only grown explicitly in grow calls.
+			nextAllocSize = db.growSize(nextMmapSize, nextAllocSize)
+		}
+		if nextAllocSize > db.MaxSize {
+			db.Logger().Errorf("[GOOS: %s, GOARCH: %s] maximum db size reached, minSize: %d (allocSize: %d), db.MaxSize: %d", runtime.GOOS, runtime.GOARCH, minsz, nextAllocSize, db.MaxSize)
+			return nil, berrors.ErrMaxSizeReached
+		}
+	}
 	if minsz >= db.datasz {
 		if err := db.mmap(minsz); err != nil {
 			if err == berrors.ErrMaxSizeReached {
@@ -1195,18 +1232,7 @@ func (db *DB) grow(sz int) error {
 		return nil
 	}
 
-	// If the data is smaller than the alloc size then only allocate what's needed.
-	// Once it goes over the allocation size then allocate in chunks.
-	if db.datasz <= db.AllocSize {
-		sz = db.datasz
-	} else {
-		sz += db.AllocSize
-	}
-
-	if !db.readOnly && db.MaxSize > 0 && sz > db.MaxSize {
-		lg.Errorf("[GOOS: %s, GOARCH: %s] maximum db size reached, size: %d, db.MaxSize: %d", runtime.GOOS, runtime.GOARCH, sz, db.MaxSize)
-		return berrors.ErrMaxSizeReached
-	}
+	sz = db.growSize(db.datasz, sz)
 
 	// Truncate and fsync to ensure file size metadata is flushed.
 	// https://github.com/boltdb/bolt/issues/284
@@ -1232,6 +1258,16 @@ func (db *DB) grow(sz int) error {
 	}
 
 	return nil
+}
+
+func (db *DB) growSize(mmapSize, growSize int) int {
+	// If the data is smaller than the alloc size then only allocate what's needed.
+	// Once it goes over the allocation size then allocate in chunks.
+	if mmapSize <= db.AllocSize {
+		return mmapSize
+	} else {
+		return growSize + db.AllocSize
+	}
 }
 
 func (db *DB) IsReadOnly() bool {
@@ -1333,7 +1369,7 @@ type Options struct {
 	// PageSize overrides the default OS page size.
 	PageSize int
 
-	// MaxSize sets the maximum size of the data file. <=0 means no maximum.
+	// MaxSize sets the maximum size of the data file. A value <= 0 means no limit.
 	MaxSize int
 
 	// NoSync sets the initial value of DB.NoSync. Normally this can just be

--- a/db_test.go
+++ b/db_test.go
@@ -1516,11 +1516,11 @@ func TestDBUnmap(t *testing.T) {
 	db.DB = nil
 }
 
-// Convenience function for inserting a bunch of keys with 1000 byte values
-func fillDBWithKeys(db *btesting.DB, numKeys int) error {
+// Convenience function for inserting a bunch of keys with values of a specific size (in bytes)
+func fillDBWithKeys(db *btesting.DB, numKeys, valueSize int) error {
 	return db.Fill([]byte("data"), 1, numKeys,
 		func(tx int, k int) []byte { return []byte(fmt.Sprintf("%04d", k)) },
-		func(tx int, k int) []byte { return make([]byte, 1000) },
+		func(tx int, k int) []byte { return make([]byte, valueSize) },
 	)
 }
 
@@ -1576,14 +1576,18 @@ func TestDB_MaxSizeNotExceeded(t *testing.T) {
 			path := db.Path()
 
 			// The data file should be 4 MiB now (expanded once from zero).
-			// It should have space for roughly 16 more entries before trying to grow
-			// Keep inserting until grow is required
-			err := fillDBWithKeys(db, 100)
+			// It should have space for roughly one more entry with value size 100kB before trying to grow
+			// This next insert should be too big
+			err := fillDBWithKeys(db, 2, 100000)
 			assert.ErrorIs(t, err, berrors.ErrMaxSizeReached)
 
 			newSz := fileSize(path)
 			require.Greater(t, newSz, int64(0), "unexpected new file size: %d", newSz)
 			assert.LessOrEqual(t, newSz, int64(db.MaxSize), "The size of the data file should not exceed db.MaxSize")
+
+			// Now try another write that shouldn't increase the max size
+			err = fillDBWithKeys(db, 1, 1)
+			assert.NoError(t, err, "Adding an entry after a failed, oversized write should not error")
 
 			err = db.Close()
 			require.NoError(t, err, "Closing the re-opened database should succeed")
@@ -1600,7 +1604,7 @@ func TestDB_MaxSizeExceededCanOpen(t *testing.T) {
 	path := db.Path()
 
 	// Insert a reasonable amount of data below the max size.
-	err := fillDBWithKeys(db, 2000)
+	err := fillDBWithKeys(db, 2000, 1000)
 	require.NoError(t, err, "fillDbWithKeys should succeed")
 
 	err = db.Close()
@@ -1624,15 +1628,8 @@ func TestDB_MaxSizeExceededCanOpen(t *testing.T) {
 
 // Ensure that opening a database that is beyond the maximum size succeeds,
 // even when InitialMmapSize is above the limit (mmaps should not affect file size)
-// This test exists for platforms where Truncate should not be called during mmap
 // https://github.com/etcd-io/bbolt/issues/928
 func TestDB_MaxSizeExceededCanOpenWithHighMmap(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// In Windows, the file must be expanded to the mmap initial size,
-		// so this test doesn't run in Windows.
-		t.SkipNow()
-	}
-
 	// Open a data file.
 	db := createFilledDB(t, nil, 4*1024*1024, 2000) // adjust allocation jumps to 4 MiB, fill with 2000 1KB entries
 	path := db.Path()
@@ -1657,36 +1654,212 @@ func TestDB_MaxSizeExceededCanOpenWithHighMmap(t *testing.T) {
 	require.NoError(t, err, "Closing the re-opened database should succeed")
 }
 
-// Ensure that when InitialMmapSize is above the limit, opening a database
-// that is beyond the maximum size fails in Windows.
-// In Windows, the file must be expanded to the mmap initial size.
-// https://github.com/etcd-io/bbolt/issues/928
+// Ensure that on Windows, mmap never expands the file speculatively via
+// InitialMmapSize, and that the database remains fully usable after such an
+// open. https://github.com/etcd-io/bbolt/issues/928
 func TestDB_MaxSizeExceededDoesNotGrow(t *testing.T) {
 	if runtime.GOOS != "windows" {
-		// This test is only relevant on Windows
 		t.SkipNow()
 	}
 
-	// Open a data file.
-	db := createFilledDB(t, nil, 4*1024*1024, 2000) // adjust allocation jumps to 4 MiB, fill with 2000 1KB entries
-	path := db.Path()
+	// Build a filled database to use as the base for all sub-tests.
+	// 4 MiB allocation jumps, 2000 × 1 KB entries → file lands at ~4 MiB.
+	base := createFilledDB(t, nil, 4*1024*1024, 2000)
+	basePath := base.Path()
+	require.NoError(t, base.Close())
 
-	err := db.Close()
-	require.NoError(t, err, "Close should succeed")
+	baseSize := fileSize(basePath)
+	require.Greater(t, baseSize, int64(1024*1024), "base DB too small for test: %d", baseSize)
 
-	// The data file should be 4 MiB now (expanded once from zero).
-	minimumSizeForTest := int64(1024 * 1024)
-	newSz := fileSize(path)
-	assert.GreaterOrEqual(t, newSz, minimumSizeForTest, "unexpected new file size: %d. Expected at least %d", newSz, minimumSizeForTest)
+	// copyDB snapshots the base file into a fresh temp path so each sub-test
+	// gets an independent copy.
+	copyDB := func(t *testing.T) string {
+		t.Helper()
+		data, err := os.ReadFile(basePath)
+		require.NoError(t, err)
+		dst := filepath.Join(t.TempDir(), "db")
+		require.NoError(t, os.WriteFile(dst, data, 0600))
+		return dst
+	}
 
-	// Now try to re-open the database with an extremely small max size and
-	// an initial mmap size to be greater than the actual file size, forcing an illegal grow on open
-	t.Logf("Reopening bbolt DB at: %s", path)
-	_, err = btesting.OpenDBWithOption(t, path, &bolt.Options{
-		MaxSize:         1,
-		InitialMmapSize: int(newSz) * 2,
+	testCases := []struct {
+		name            string
+		initialMmapSize int // 0 means unset
+		maxSize         int // 0 means unset
+		// expected file size after re-open (0 means "same as baseSize")
+		wantSize    int64
+		wantOpenErr error // nil means open must succeed
+	}{
+		{
+			// On Windows, mmap expands the file to the mapped size immediately.
+			// When InitialMmapSize > MaxSize, the mmap call itself would grow the
+			// file past MaxSize, so Open is rejected with ErrMaxSizeReached rather
+			// than silently exceeding the limit.
+			name:            "InitialMmapSize larger than file does not grow",
+			initialMmapSize: int(baseSize) * 2,
+			maxSize:         1,
+			wantSize:        baseSize,
+			wantOpenErr:     berrors.ErrMaxSizeReached,
+		},
+		{
+			name:            "InitialMmapSize equal to file size does not grow",
+			initialMmapSize: int(baseSize),
+			maxSize:         1,
+			wantSize:        baseSize,
+		},
+		{
+			name:            "InitialMmapSize smaller than file size does not shrink",
+			initialMmapSize: int(baseSize) / 2,
+			maxSize:         1,
+			wantSize:        baseSize,
+		},
+		{
+			name:            "no InitialMmapSize does not grow",
+			initialMmapSize: 0,
+			maxSize:         1,
+			wantSize:        baseSize,
+		},
+		{
+			name:            "no MaxSize with high InitialMmapSize grows to InitialMmapSize",
+			initialMmapSize: int(baseSize) * 2,
+			maxSize:         0,
+			wantSize:        baseSize * 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := copyDB(t)
+
+			opts := &bolt.Options{InitialMmapSize: tc.initialMmapSize}
+			if tc.maxSize > 0 {
+				opts.MaxSize = tc.maxSize
+			}
+
+			db, err := btesting.OpenDBWithOption(t, path, opts)
+			if tc.wantOpenErr != nil {
+				require.ErrorIs(t, err, tc.wantOpenErr, "open should fail with expected error")
+			} else {
+				require.NoError(t, err, "open should succeed")
+				db.MustClose()
+			}
+
+			got := fileSize(path)
+			assert.Equal(t, tc.wantSize, got, "unexpected file size after re-open")
+		})
+	}
+}
+
+func TestDB_WindowsMMapReadsAndWritesWithMaxSize(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.SkipNow()
+	}
+
+	base := createFilledDB(t, nil, 4*1024*1024, 2000)
+	basePath := base.Path()
+	require.NoError(t, base.Close())
+	baseSize := fileSize(basePath)
+
+	copyDB := func(t *testing.T) string {
+		t.Helper()
+		data, err := os.ReadFile(basePath)
+		require.NoError(t, err)
+		dst := filepath.Join(t.TempDir(), "db")
+		require.NoError(t, os.WriteFile(dst, data, 0600))
+		return dst
+	}
+
+	testCases := []struct {
+		name            string
+		initialMMapSize int
+		maxSize         int
+		op              func(db *btesting.DB) error
+		wantOpErr       error
+	}{
+		{
+			name:            "reads succeed after open with InitialMMapSize equal to file size",
+			initialMMapSize: int(baseSize),
+			maxSize:         1,
+			op: func(db *btesting.DB) error {
+				return db.View(func(tx *bolt.Tx) error {
+					b := tx.Bucket([]byte("data"))
+					require.NotNil(t, b, "bucket 'data' must exist")
+					require.NotNil(t, b.Get([]byte("0001")), "key 0001 must be readable")
+					return nil
+				})
+			},
+		},
+		{
+			name:            "small writes succeed after open with high InitialMMapSize",
+			initialMMapSize: int(baseSize) * 2,
+			maxSize:         int(baseSize) * 4,
+			op: func(db *btesting.DB) error {
+				return fillDBWithKeys(db, 1, 1)
+			},
+		},
+		{
+			name:            "oversized writes return ErrMaxSizeReached",
+			initialMMapSize: int(baseSize) / 2,
+			maxSize:         int(baseSize),
+			op: func(db *btesting.DB) error {
+				return fillDBWithKeys(db, 2, 100000)
+			},
+			wantOpErr: berrors.ErrMaxSizeReached,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := copyDB(t)
+			db, err := btesting.OpenDBWithOption(t, path, &bolt.Options{
+				MaxSize:         tc.maxSize,
+				InitialMmapSize: tc.initialMMapSize,
+			})
+			require.NoError(t, err)
+			defer db.MustClose()
+
+			opErr := tc.op(db)
+			if tc.wantOpErr != nil {
+				require.ErrorIs(t, opErr, tc.wantOpErr)
+			} else {
+				require.NoError(t, opErr)
+			}
+		})
+	}
+}
+
+func TestDB_MaxSizeWithHighInitialMMapDoesNotGrowOnWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
+	maxSize := 64 * 1024 * 1024
+	initialMMapSize := maxSize * 2
+	valueSize := 50 * 1024 * 1024
+
+	dbPath := filepath.Join(t.TempDir(), "db")
+	db, err := bolt.Open(dbPath, 0600, &bolt.Options{
+		MaxSize:         maxSize,
+		InitialMmapSize: initialMMapSize,
 	})
-	assert.Error(t, err, "Opening the DB with InitialMmapSize > MaxSize should cause an error on Windows")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	value := bytes.Repeat([]byte("v"), valueSize)
+	err = db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucket([]byte("data"))
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte("large-value"), value)
+	})
+	assert.ErrorIs(t, err, berrors.ErrMaxSizeReached)
+
+	newSz := fileSize(dbPath)
+	assert.Greater(t, newSz, int64(0), "unexpected new file size: %d", newSz)
+	assert.LessOrEqual(t, newSz, int64(maxSize), "The size of the data file should not exceed MaxSize")
 }
 
 func TestDB_HugeValue(t *testing.T) {

--- a/db_test.go
+++ b/db_test.go
@@ -1688,7 +1688,7 @@ func TestDB_MaxSizeExceededDoesNotGrow(t *testing.T) {
 		maxSize         int // 0 means unset
 		// expected file size after re-open (0 means "same as baseSize")
 		wantSize    int64
-		wantOpenErr error // nil means open must succeed
+		wantOpenErr error
 	}{
 		{
 			// On Windows, mmap expands the file to the mapped size immediately.


### PR DESCRIPTION
Fixes https://github.com/etcd-io/bbolt/issues/1108

Continuation of https://github.com/etcd-io/bbolt/pull/1130

cc @ahrtr @ivanvc @fuweid @serathius 