### PR TITLE
Update version to 1.5.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version shows the last bbolt binary version released.
-	Version = "1.4.0-alpha.0"
+	Version = "1.5.0"
 )


### PR DESCRIPTION
The v1.5.0 release was already released, but `version/version.go` was never updated. 
Align the version string with the release.