### PR TITLE
CHANGELOG: add v1.5.1 entry

### DIFF
--- a/CHANGELOG/CHANGELOG-1.5.md
+++ b/CHANGELOG/CHANGELOG-1.5.md
@@ -1,6 +1,13 @@
 
 <hr>
 
+## v1.5.1(TBD)
+
+### BoltDB
+- [Fix version string not updated for v1.5.0 release](https://github.com/etcd-io/bbolt/pull/1230)
+
+<hr>
+
 ## v1.5.0(2026-06-21)
 There isn't any production code change since v1.5.0-rc.0. Only golang patch version is bumped.
 


### PR DESCRIPTION
Follow-up to #1229.

Adds a v1.5.1(TBD) changelog entry to CHANGELOG-1.5.md tracking that fix.