### PR TITLE
fix: correct typos in comments and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,7 +1008,7 @@ Below is a list of public, open source projects that use Bolt:
 * [Freehold](http://tshannon.bitbucket.org/freehold/) - An open, secure, and lightweight platform for your files and data.
 * [Go Report Card](https://goreportcard.com/) - Go code quality report cards as a (free and open source) service.
 * [GoWebApp](https://github.com/josephspurrier/gowebapp) - A basic MVC web application in Go using BoltDB.
-* [GoShort](https://github.com/pankajkhairnar/goShort) - GoShort is a URL shortener written in Golang and BoltDB for persistent key/value storage and for routing it's using high performent HTTPRouter.
+* [GoShort](https://github.com/pankajkhairnar/goShort) - GoShort is a URL shortener written in Golang and BoltDB for persistent key/value storage and for routing it's using high performant HTTPRouter.
 * [gopherpit](https://github.com/gopherpit/gopherpit) - A web service to manage Go remote import paths with custom domains
 * [gokv](https://github.com/philippgille/gokv) - Simple key-value store abstraction and implementations for Go (Redis, Consul, etcd, bbolt, BadgerDB, LevelDB, Memcached, DynamoDB, S3, PostgreSQL, MongoDB, CockroachDB and many more)
 * [goraphdb](https://github.com/mstrYoda/goraphdb) - A graph database provides Cypher query, fluent builder and management UI.

--- a/bucket.go
+++ b/bucket.go
@@ -395,7 +395,7 @@ func (b *Bucket) MoveBucket(key []byte, dstBucket *Bucket) (err error) {
 	delete(b.buckets, string(newKey))
 	c.node().del(newKey)
 
-	// add te sub-bucket to the destination bucket
+	// add the sub-bucket to the destination bucket
 	newValue := cloneBytes(v)
 	curDst.node().put(newKey, newKey, newValue, 0, common.BucketLeafFlag)
 

--- a/db.go
+++ b/db.go
@@ -1295,7 +1295,7 @@ func (db *DB) freepages() []common.Pgid {
 		tx.recursivelyCheckBucket(&tx.root, reachable, nofreed, HexKVStringer(), ech)
 	}()
 	// following for loop will exit once channel is closed in the above goroutine.
-	// we don't need to wait explictly with a waitgroup
+	// we don't need to wait explicitly with a waitgroup
 	for e := range ech {
 		panic(fmt.Sprintf("freepages: failed to get all reachable pages (%v)", e))
 	}


### PR DESCRIPTION
Fix three spelling mistakes found via codespell:

- `bucket.go` line 398: `add te sub-bucket` -> `add the sub-bucket`
- `db.go` line 1298: `explictly` -> `explicitly`
- `README.md` line 1011: `performent` -> `performant`

All fixes are in comments and documentation only — no code logic or identifiers were changed.