### PR TITLE
Generate unified version output for both 'bbolt version' and 'bbolt -v'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 COMMIT=`git rev-parse --short HEAD`
-GOLDFLAGS="-X main.branch $(BRANCH) -X main.commit $(COMMIT)"
+GOLDFLAGS="-X go.etcd.io/bbolt/version.Branch=$(BRANCH) -X go.etcd.io/bbolt/version.Commit=$(COMMIT)"
 GOFILES = $(shell find . -name \*.go)
 REPOSITORY_ROOT := $(shell git rev-parse --show-toplevel)
 GOTOOLCHAIN ?= go$(shell cat $(REPOSITORY_ROOT)/.go-version)
@@ -66,7 +66,7 @@ coverage:
 BOLT_CMD=bbolt
 
 build:
-	go build -o bin/${BOLT_CMD} ./cmd/${BOLT_CMD}
+	go build -ldflags ${GOLDFLAGS} -o bin/${BOLT_CMD} ./cmd/${BOLT_CMD}
 
 .PHONY: clean
 clean: # Clean binaries

--- a/cmd/bbolt/command/command_root.go
+++ b/cmd/bbolt/command/command_root.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"github.com/spf13/cobra"
+
+	"go.etcd.io/bbolt/version"
 )
 
 const (
@@ -13,8 +15,9 @@ func NewRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     cliName,
 		Short:   cliDescription,
-		Version: "dev",
+		Version: version.Version,
 	}
+	rootCmd.SetVersionTemplate(versionOutput())
 
 	rootCmd.AddCommand(
 		newVersionCommand(),

--- a/cmd/bbolt/command/command_version.go
+++ b/cmd/bbolt/command/command_version.go
@@ -9,15 +9,26 @@ import (
 	"go.etcd.io/bbolt/version"
 )
 
+func versionOutput() string {
+	out := fmt.Sprintf("bbolt Version: %s\n", version.Version)
+	if version.Branch != "" {
+		out += fmt.Sprintf("Git Branch: %s\n", version.Branch)
+	}
+	if version.Commit != "" {
+		out += fmt.Sprintf("Git Commit: %s\n", version.Commit)
+	}
+	out += fmt.Sprintf("Go Version: %s\nGo OS/Arch: %s/%s\n",
+		runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	return out
+}
+
 func newVersionCommand() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "print the current version of bbolt",
 		Long:  "print the current version of bbolt",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("bbolt Version: %s\n", version.Version)
-			fmt.Printf("Go Version: %s\n", runtime.Version())
-			fmt.Printf("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+			fmt.Print(versionOutput())
 		},
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -3,4 +3,9 @@ package version
 var (
 	// Version shows the last bbolt binary version released.
 	Version = "1.5.0"
+
+	// Branch and Commit are set via -ldflags at build time to identify
+	// the git branch and commit the binary was built from.
+	Branch = ""
+	Commit = ""
 )


### PR DESCRIPTION
Fix https://github.com/etcd-io/bbolt/issues/1249

```
$ ./bin/bbolt version
bbolt Version: 1.5.0
Git Branch: 20260813_version
Git Commit: 54b140d
Go Version: go1.25.12
Go OS/Arch: darwin/arm64

$ ./bin/bbolt -v
bbolt Version: 1.5.0
Git Branch: 20260813_version
Git Commit: 54b140d
Go Version: go1.25.12
```