### PR TITLE
[release-1.4] Pin benchstat version to maintain Go 1.25 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,4 @@ test-benchmark-compare: install-benchstat
 
 .PHONY: install-benchstat
 install-benchstat:
-	go install golang.org/x/perf/cmd/benchstat@latest
+	go install golang.org/x/perf/cmd/benchstat@fd4a688df89207abdabe0a0cf5b2cd9ccfd376d2


### PR DESCRIPTION
Required by https://github.com/etcd-io/bbolt/pull/1262 - https://github.com/etcd-io/bbolt/actions/runs/32365217422/job/96486005335?pr=1262

Pin `golang.org/x/perf/cmd/benchstat` to commit `fd4a688df89207abdabe0a0cf5b2cd9ccfd376d2` instead of using `@latest`.

The benchmark job started failing because `golang.org/x/perf/cmd/benchstat@latest` now resolves to a version of `golang.org/x/perf` that requires Go 1.26+, while the CI workflow currently runs with Go 1.25.x. The upstream `x/perf` repository recently [updated](https://github.com/golang/perf/commit/ebcb4798430da1bb6761f0a1c8921251caba88de) its Go directive to require Go 1.26.