### PR TITLE
Use a lock owned by the open file descriptor on Android

### DIFF
--- a/bolt_android.go
+++ b/bolt_android.go
@@ -8,8 +8,27 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"go.etcd.io/bbolt/errors"
 	"go.etcd.io/bbolt/internal/common"
 )
+
+// Android is an ordinary Linux system, except on the FUSE mount that backs
+// emulated external storage (/storage/emulated/...): MediaProvider's FUSE
+// daemon advertises FUSE_CAP_FLOCK_LOCKS but leaves the flock handler
+// unimplemented, so libfuse answers the request with ENOSYS and the kernel
+// forwards that to userspace rather than falling back to local locking.
+// flock(2) fails with ENOSYS there, while databases in the app's own data
+// directory are unaffected.
+// See https://github.com/etcd-io/bbolt/issues/558.
+//
+// Open file description locks work on that mount and carry the same ownership
+// semantics as flock(2): the lock belongs to the open file description, so a
+// second Open of the same file conflicts even from within one process, and
+// closing another descriptor to the file leaves the lock in place.
+//
+// F_OFD_SETLK requires Linux 3.15, which this path always has: it is only
+// reached on the FUSE mount, introduced in Android 11 with a 4.14 or newer
+// kernel.
 
 // flock acquires an advisory lock on a file descriptor.
 func flock(db *DB, exclusive bool, timeout time.Duration) error {
@@ -18,25 +37,18 @@ func flock(db *DB, exclusive bool, timeout time.Duration) error {
 		t = time.Now()
 	}
 	fd := db.file.Fd()
-	var lockType int16
-	if exclusive {
-		lockType = syscall.F_WRLCK
-	} else {
-		lockType = syscall.F_RDLCK
-	}
 	for {
 		// Attempt to obtain an exclusive lock.
-		lock := syscall.Flock_t{Type: lockType}
-		err := syscall.FcntlFlock(fd, syscall.F_SETLK, &lock)
+		err := lockFile(fd, exclusive)
 		if err == nil {
 			return nil
-		} else if err != syscall.EAGAIN {
+		} else if !isLockHeldByOther(err) {
 			return err
 		}
 
 		// If we timed out then return an error.
 		if timeout != 0 && time.Since(t) > timeout-flockRetryTimeout {
-			return ErrTimeout
+			return errors.ErrTimeout
 		}
 
 		// Wait for a bit and try again.
@@ -46,12 +58,48 @@ func flock(db *DB, exclusive bool, timeout time.Duration) error {
 
 // funlock releases an advisory lock on a file descriptor.
 func funlock(db *DB) error {
-	var lock syscall.Flock_t
-	lock.Start = 0
-	lock.Len = 0
-	lock.Type = syscall.F_UNLCK
-	lock.Whence = 0
-	return syscall.FcntlFlock(uintptr(db.file.Fd()), syscall.F_SETLK, &lock)
+	fd := db.file.Fd()
+	err := syscall.Flock(int(fd), syscall.LOCK_UN)
+	if err != syscall.ENOSYS {
+		return err
+	}
+	return ofdSetlk(fd, unix.F_UNLCK)
+}
+
+// lockFile takes a non-blocking lock on the whole file, using flock(2) where
+// the filesystem implements it and an open file description lock elsewhere.
+func lockFile(fd uintptr, exclusive bool) error {
+	how := syscall.LOCK_SH
+	lockType := int16(unix.F_RDLCK)
+	if exclusive {
+		how = syscall.LOCK_EX
+		lockType = unix.F_WRLCK
+	}
+
+	err := syscall.Flock(int(fd), how|syscall.LOCK_NB)
+	if err != syscall.ENOSYS {
+		return err
+	}
+	return ofdSetlk(fd, lockType)
+}
+
+// ofdSetlk applies lockType to the whole file as an open file description lock.
+func ofdSetlk(fd uintptr, lockType int16) error {
+	lock := unix.Flock_t{
+		Type:   lockType,
+		Whence: 0, // SEEK_SET
+		Start:  0,
+		Len:    0, // to the end of the file
+	}
+	return unix.FcntlFlock(fd, unix.F_OFD_SETLK, &lock)
+}
+
+// isLockHeldByOther reports whether err means the lock is currently held
+// elsewhere, so the attempt is worth retrying. flock(2) reports this as
+// EWOULDBLOCK, which is EAGAIN on Linux; fcntl(2) may use either EAGAIN or
+// EACCES.
+func isLockHeldByOther(err error) bool {
+	return err == syscall.EAGAIN || err == syscall.EACCES
 }
 
 // mmap memory maps a DB's data file.

--- a/db_test.go
+++ b/db_test.go
@@ -67,6 +67,31 @@ func TestOpen(t *testing.T) {
 	}
 }
 
+// Ensure that a second Open of a database file that is already open in this
+// process times out. bbolt's file lock is owned by the open file description,
+// so it excludes other handles within a process just as it excludes other
+// processes. See https://github.com/etcd-io/bbolt/issues/558.
+func TestOpen_ErrTimeout_SameProcess(t *testing.T) {
+	switch runtime.GOOS {
+	case "aix", "solaris":
+		// These platforms lock with POSIX record locks, which are owned by
+		// the process.
+		t.Skip("file locks on this platform are process-owned")
+	}
+
+	path := tempfile()
+	defer os.RemoveAll(path)
+
+	db, err := bolt.Open(path, 0600, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	_, err = bolt.Open(path, 0600, &bolt.Options{Timeout: 100 * time.Millisecond})
+	require.ErrorIs(t, err, berrors.ErrTimeout)
+}
+
 // Regression validation for https://github.com/etcd-io/bbolt/pull/122.
 // Tests multiple goroutines simultaneously opening a database.
 func TestOpen_MultipleGoroutines(t *testing.T) {


### PR DESCRIPTION
Fixes the file lock on Android. The lock must exclude a second `Open` of the
same database. At present it does not.

### What is wrong today

PR #571 moved Android out of `bolt_unix.go` and into `bolt_android.go`, to work
around `flock(2)` failures on Android. The new file locks with POSIX record
locks (`fcntl(F_SETLK)`), copied from `bolt_solaris.go`. A POSIX record lock
belongs to the process, not to the open file descriptor. The lock therefore
loses the two properties that it exists to provide.

Measured on an Android 14 emulator (API 34, kernel 6.1.23), inside a real app
process:

```
[2] fcntl(F_SETLK) same process, two fds  <- current bolt_android.go
  F_SETLK F_WRLCK on fd_a                        => OK (lock acquired)
  F_SETLK F_WRLCK on fd_b                        => OK (lock acquired)
  F_SETLK F_RDLCK on fd_c (downgrade?)           => OK (lock acquired)
  CHILD PROCESS setlk                            => resource temporarily unavailable
  (closed fd_b -- POSIX says this drops ALL of this process's locks on the file)
  CHILD PROCESS setlk                            => OK (lock acquired)

[5] bbolt.Open same path twice in one process
  first  bolt.Open => err=<nil>
  second bolt.Open => err=<nil>  (want: timeout)
```

1. A second `Open` in the same process succeeds. Two `DB` handles then write
   meta pages and freelist pages to one file. This is the corruption that the
   lock must prevent.
2. A close of any descriptor to the file releases every lock that the process
   holds on that file. Another process can then take the write lock. Exclusion
   between processes is the property that `Open` documents, and it is lost too.

### Why `flock(2)` failed

Android does not remove or restrict `flock`. `flock` fails only on the FUSE
mount that provides emulated external storage. In `pf_init()`, the MediaProvider
FUSE daemon adds `FUSE_CAP_FLOCK_LOCKS` to `conn->want`. But `pf_flock` and the
`.flock` entry in the ops table are commented out. libfuse therefore replies
`ENOSYS` in `do_setlk_common`. `fc->no_flock` is 0, so `fuse_file_flock()`
returns that reply without change. There is no local fallback.

The daemon does not advertise `FUSE_CAP_POSIX_LOCKS`. `fcntl` locks therefore
use the `posix_lock_file()` path and stay in the kernel. This is why `fcntl`
appeared to work.

Same emulator, same app process, two directories:

| Android 14 (API 34) | `/data/user/0/<pkg>/files` (ext4) | `/storage/emulated/0/Android/data/<pkg>` (FUSE) |
|---|---|---|
| `flock(2)`          | OK    | **ENOSYS** |
| `fcntl(F_SETLK)`    | OK    | OK |
| `fcntl(F_OFD_SETLK)`| OK    | OK |

The failure depends on the filesystem, not on the Android release. It does not
affect a database in the app's own data directory.

### This change

Use `flock(2)`. On `ENOSYS`, use an open file description lock (`F_OFD_SETLK`)
instead. An OFD lock belongs to the open file description, as a `flock` lock
does. Both properties above therefore hold. `funlock` makes the same choice.
The choice is stable for a given file, because it is a property of the
filesystem.

Storage that implements `flock(2)` continues to use it, and behaves as on every
other unix platform. `F_OFD_SETLK` requires Linux 3.15. The fallback path always
has it, because the path is reached only on the FUSE mount. Android 11
introduced that mount with a 4.14 or later kernel.

### Testing

Added `TestOpen_ErrTimeout_SameProcess`. It skips on aix and solaris, which
still lock with POSIX record locks.

Verified on an Android 14 emulator (API 34, arm64). A probe and this package's
test binary ran from a real zygote-spawned app process (`Seccomp: 2`), on both
filesystems:

```
##########  INTERNAL (ext4)  /data/user/0/io.etcd.lockprobe2/files/lk
  flock(2)            => OK (lock acquired)
  fcntl F_OFD_SETLK   => OK (lock acquired)
  first  bolt.Open    => err=<nil>
  second bolt.Open    => err=timeout   (want: timeout)
  CHILD PROCESS bolt  => timeout
  reopen after Close  => err=<nil>     (want: nil)
--- PASS: TestOpen_ErrTimeout_SameProcess

##########  EXTERNAL (FUSE)  /storage/emulated/0/Android/data/io.etcd.lockprobe2/files/lk
  flock(2)            => function not implemented (errno=38)
  fcntl F_OFD_SETLK   => OK (lock acquired)
  first  bolt.Open    => err=<nil>
  second bolt.Open    => err=timeout   (want: timeout)
  CHILD PROCESS bolt  => timeout
  reopen after Close  => err=<nil>     (want: nil)
--- PASS: TestOpen_ErrTimeout_SameProcess
```

The full test suite of the package also passes on that emulator, run from the
app's data directory.

No other platform changes: `bolt_android.go` builds only for `GOOS=android`.
