### PR TITLE
chore: delete redundant nil assignment

### DIFF
--- a/node.go
+++ b/node.go
@@ -353,7 +353,6 @@ func (n *node) spill() error {
 	// If the root node split and created a new root then we need to spill that
 	// as well. We'll clear out the children to make sure it doesn't try to respill.
 	if n.parent != nil && n.parent.pgid == 0 {
-		n.children = nil
 		return n.parent.spill()
 	}
 


### PR DESCRIPTION
delete redundant nil assignment which has done in line 312
<img width="1494" height="474" alt="image" src="https://github.com/user-attachments/assets/1df22ea0-70fc-49e4-acaf-7d7b94111c1d" />
