### PR TITLE
perf: merge freelist pages without redundant allocations

### DIFF
--- a/internal/common/page.go
+++ b/internal/common/page.go
@@ -3,7 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"unsafe"
 )
 
@@ -346,7 +346,8 @@ func (s Pgids) Len() int           { return len(s) }
 func (s Pgids) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s Pgids) Less(i, j int) bool { return s[i] < s[j] }
 
-// Merge returns the sorted union of a and b.
+// Merge returns the sorted concatenation of a and b.
+// Both inputs must be sorted and must not contain the same page ID.
 func (s Pgids) Merge(b Pgids) Pgids {
 	// Return the opposite slice if one is nil.
 	if len(s) == 0 {
@@ -356,48 +357,72 @@ func (s Pgids) Merge(b Pgids) Pgids {
 		return s
 	}
 	merged := make(Pgids, len(s)+len(b))
-	Mergepgids(merged, s, b)
+	mergepgids(merged, s, b)
 	return merged
 }
 
-// Mergepgids copies the sorted union of a and b into dst.
+// MergeInPlace merges b into s, reusing the backing array of s when it has
+// enough spare capacity. The backing array of s is always overwritten. The
+// returned slice must be used instead of s. Both inputs must be sorted, must
+// not contain the same page ID, and must not alias each other.
+func (s Pgids) MergeInPlace(b Pgids) Pgids {
+	if len(s) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return s
+	}
+
+	total := len(s) + len(b)
+	merged := slices.Grow(s, len(b))[:total]
+	mergepgidsInPlace(merged, s, b)
+	return merged
+}
+
+// Mergepgids copies the sorted concatenation of a and b into dst.
+// The inputs must be sorted and dst must not overlap either input.
 // If dst is too small, it panics.
 func Mergepgids(dst, a, b Pgids) {
 	if len(dst) < len(a)+len(b) {
 		panic(fmt.Errorf("mergepgids bad len %d < %d + %d", len(dst), len(a), len(b)))
 	}
-	// Copy in the opposite slice if one is nil.
-	if len(a) == 0 {
-		copy(dst, b)
-		return
-	}
-	if len(b) == 0 {
-		copy(dst, a)
-		return
-	}
+	mergepgids(dst, a, b)
+}
 
-	// Merged will hold all elements from both lists.
-	merged := dst[:0]
-
-	// Assign lead to the slice with a lower starting value, follow to the higher value.
-	lead, follow := a, b
-	if b[0] < a[0] {
-		lead, follow = b, a
-	}
-
-	// Continue while there are elements in the lead.
-	for len(lead) > 0 {
-		// Merge largest prefix of lead that is ahead of follow[0].
-		n := sort.Search(len(lead), func(i int) bool { return lead[i] > follow[0] })
-		merged = append(merged, lead[:n]...)
-		if n >= len(lead) {
-			break
+func mergepgids(dst, a, b Pgids) {
+	i, j, k := 0, 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i] < b[j] {
+			dst[k] = a[i]
+			i++
+		} else {
+			dst[k] = b[j]
+			j++
 		}
-
-		// Swap lead and follow.
-		lead, follow = follow, lead[n:]
+		k++
 	}
 
-	// Append what's left in follow.
-	_ = append(merged, follow...)
+	if i < len(a) {
+		copy(dst[k:], a[i:])
+		return
+	}
+	copy(dst[k:], b[j:])
+}
+
+func mergepgidsInPlace(dst, a, b Pgids) {
+	i, j := len(a), len(b)
+	for k := len(dst); k > 0; {
+		k--
+		switch {
+		case i == 0:
+			dst[k] = b[j-1]
+			j--
+		case j == 0 || a[i-1] > b[j-1]:
+			dst[k] = a[i-1]
+			i--
+		default:
+			dst[k] = b[j-1]
+			j--
+		}
+	}
 }

--- a/internal/common/page_test.go
+++ b/internal/common/page_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"testing"
 	"testing/quick"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Ensure that the page type can be returned in human readable format.
@@ -68,5 +70,71 @@ func TestPgids_merge_quick(t *testing.T) {
 		return true
 	}, nil); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPgids_mergeInPlace(t *testing.T) {
+	tests := []struct {
+		name string
+		a    Pgids
+		b    Pgids
+		want Pgids
+	}{
+		{name: "interleaved", a: Pgids{2, 5, 8}, b: Pgids{3, 4, 9}, want: Pgids{2, 3, 4, 5, 8, 9}},
+		{name: "leading", a: Pgids{2, 3}, b: Pgids{10, 12}, want: Pgids{2, 3, 10, 12}},
+		{name: "trailing", a: Pgids{10, 12}, b: Pgids{2, 3}, want: Pgids{2, 3, 10, 12}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backing := make(Pgids, len(tt.a), len(tt.a)+len(tt.b))
+			copy(backing, tt.a)
+
+			got := backing.MergeInPlace(tt.b)
+			require.Equal(t, tt.want, got)
+			if len(tt.a) != 0 && len(tt.b) != 0 && &got[0] != &backing[0] {
+				t.Fatal("MergeInPlace did not reuse the destination backing array")
+			}
+		})
+	}
+}
+
+var benchmarkPgidsMergeSink Pgids
+
+func benchmarkPgids(size int) (Pgids, Pgids) {
+	a := make(Pgids, 0, size)
+	ids := make(Pgids, 0, size)
+	for i := range 2 * size {
+		id := Pgid(2 + 2*i)
+		if i%2 == 0 {
+			a = append(a, id)
+		} else {
+			ids = append(ids, id)
+		}
+	}
+
+	return a, ids
+}
+
+func BenchmarkPgids_merge(b *testing.B) {
+	const size = 10000
+	a, ids := benchmarkPgids(size)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkPgidsMergeSink = a.Merge(ids)
+	}
+}
+
+func BenchmarkPgids_mergeInPlace(b *testing.B) {
+	const size = 10000
+	srcA, srcB := benchmarkPgids(size)
+	dst := make(Pgids, 0, 2*size)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		s := dst[:size]
+		copy(s, srcA)
+		benchmarkPgidsMergeSink = s.MergeInPlace(srcB)
 	}
 }

--- a/internal/freelist/array.go
+++ b/internal/freelist/array.go
@@ -95,7 +95,7 @@ func (f *array) mergeSpans(ids common.Pgids) {
 			}
 		}
 	})
-	f.ids = common.Pgids(f.ids).Merge(ids)
+	f.ids = common.Pgids(f.ids).MergeInPlace(ids)
 }
 
 func NewArrayFreelist() Interface {

--- a/internal/freelist/array_test.go
+++ b/internal/freelist/array_test.go
@@ -1,6 +1,7 @@
 package freelist
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -85,7 +86,104 @@ func Test_Freelist_Array_Rollback(t *testing.T) {
 	require.Equal(t, map[common.Txid]*txPending{}, f.pending)
 }
 
+func TestFreelistArray_mergeSpans_reusesCapacity(t *testing.T) {
+	backing := make(common.Pgids, 2, 4)
+	backing[0], backing[1] = 3, 8
+
+	f := newTestArrayFreelist()
+	f.Init(backing)
+	f.mergeSpans(common.Pgids{5, 9})
+
+	require.Equal(t, common.Pgids{3, 5, 8, 9}, f.freePageIds())
+	require.Equal(t, 4, f.FreeCount())
+	require.Same(t, &backing[0], &f.freePageIds()[0])
+}
+
 func newTestArrayFreelist() *array {
 	f := NewArrayFreelist()
 	return f.(*array)
+}
+
+func benchmarkArrayInitAndMergePgids(maxPgid, mergeCount, mergeSpanLen int, spareCapacity int) (common.Pgids, common.Pgids) {
+	const gapSize = 100
+
+	mergeSpanCount := (mergeCount + mergeSpanLen - 1) / mergeSpanLen
+	requiredPageCount := mergeCount + mergeSpanCount - 1
+	if requiredPageCount > maxPgid-1 {
+		panic("invalid benchmark parameters: insufficient pgid space")
+	}
+
+	freeCount := maxPgid - mergeCount - mergeSpanCount + 1
+	initIDs := make(common.Pgids, 0, freeCount+spareCapacity)
+	mergePgids := make(common.Pgids, 0, mergeCount)
+	next := common.Pgid(2)
+	remaining := mergeCount
+
+	for remaining > 0 {
+		spanLen := min(mergeSpanLen, remaining)
+		for i := range spanLen {
+			mergePgids = append(mergePgids, next+common.Pgid(i))
+		}
+
+		next += common.Pgid(spanLen)
+		remaining -= spanLen
+		if remaining == 0 {
+			break
+		}
+
+		for range gapSize {
+			initIDs = append(initIDs, next)
+			next++
+		}
+	}
+
+	for ; next <= common.Pgid(maxPgid); next++ {
+		initIDs = append(initIDs, next)
+	}
+
+	return initIDs, mergePgids
+}
+
+func benchmarkArrayMergeSpans(b *testing.B, initIDs, mergePgids common.Pgids) {
+	b.ReportAllocs()
+	mergeIDs := append(common.Pgids(nil), mergePgids...)
+	for b.Loop() {
+		b.StopTimer()
+		f := newTestArrayFreelist()
+		f.Init(initIDs)
+		b.StartTimer()
+
+		f.mergeSpans(mergeIDs)
+		b.StopTimer()
+		require.Equal(b, len(initIDs)+len(mergeIDs), f.FreeCount())
+		b.StartTimer()
+	}
+}
+
+func Benchmark_freelist_arrayMergeSpans(b *testing.B) {
+	testCases := []struct {
+		maxPgid    int
+		mergeCount int
+	}{
+		{maxPgid: 1000, mergeCount: 500},
+		{maxPgid: 5000, mergeCount: 2500},
+		{maxPgid: 10000, mergeCount: 5000},
+	}
+
+	for _, tc := range testCases {
+		for _, mergeSpanLen := range []int{1, 16, 32, 64} {
+			name := fmt.Sprintf("max%d_merge%d_span%d", tc.maxPgid, tc.mergeCount, mergeSpanLen)
+			coldInit, mergePgids := benchmarkArrayInitAndMergePgids(tc.maxPgid, tc.mergeCount, mergeSpanLen, 0)
+			warmInit, _ := benchmarkArrayInitAndMergePgids(tc.maxPgid, tc.mergeCount, mergeSpanLen, tc.mergeCount)
+
+			b.Run(name, func(b *testing.B) {
+				b.Run("cold", func(b *testing.B) {
+					benchmarkArrayMergeSpans(b, coldInit, mergePgids)
+				})
+				b.Run("warm", func(b *testing.B) {
+					benchmarkArrayMergeSpans(b, warmInit, mergePgids)
+				})
+			})
+		}
+	}
 }


### PR DESCRIPTION

## Motivation

`Pgids.Merge` allocated a fresh result and used an alternating binary-search merge. On fragmented ranges, each swap can process very few IDs, making the merge quadratic in practice. The array freelist also could not reuse spare capacity in its existing `f.ids` backing array.

## Changes

- Implement a linear stable merge for sorted page IDs.
- Add `Pgids.MergeInPlace` for callers that own the destination slice and can guarantee the two inputs do not alias.
- Use `MergeInPlace` in the array freelist, allowing `slices.Grow` to reuse spare capacity and fill the merged result from the back.
- Add correctness tests for boundary/fragmented inputs, destination reuse, and array freelist merging.

No disk format, protocol, or public bbolt API changes.

## Benchmark

linux/amd64, Hygon C86 7265:

```text
Pgids.Merge, 2 x 10,000 alternating page IDs:
  main:  404,329 ns/op, 163,843 B/op, 1 allocs/op
  patch:  68,871 ns/op, 163,842 B/op, 1 allocs/op

Pgids.MergeInPlace, same input and reusable destination:
  patch:  37,583 ns/op,       0 B/op, 0 allocs/op

array freelist, 10,000-page space / 5,000 released IDs:
  1-page spans:  2,450,131 -> 1,073,759 ns/op; 2 -> 1 allocs/op
  16-page spans:    229,598 ->   103,490 ns/op; 2 -> 1 allocs/op
```

The array benchmark includes harness setup/reindex allocations. The `Pgids` rows are the cleaner allocation comparison.