### PR TITLE
add GOOS=js (wasm) build support

### DIFF
--- a/bolt_js.go
+++ b/bolt_js.go
@@ -1,0 +1,53 @@
+//go:build js
+
+package bbolt
+
+// js/wasm support. The browser (and other js runtimes) have no flock and no
+// mmap: file locks are no-ops — a wasm instance is single-process by
+// construction — and "mmap" reads the mapped region through the runtime's
+// file API (globalThis.fs under Go's wasm_exec.js) into an ordinary byte
+// slice. Reads through db.data observe the state at map time, which matches
+// bbolt's remap-on-grow usage. Whether opening a database works at runtime
+// depends on the filesystem the host environment provides (Node passes
+// through to the real filesystem; a browser page must install its own
+// globalThis.fs implementation).
+
+import (
+	"io"
+	"time"
+	"unsafe"
+
+	"go.etcd.io/bbolt/internal/common"
+)
+
+// flock acquires an advisory lock on a file descriptor. No-op on js.
+func flock(_ *DB, _ bool, _ time.Duration) error { return nil }
+
+// funlock releases an advisory lock on a file descriptor. No-op on js.
+func funlock(_ *DB) error { return nil }
+
+// fdatasync flushes written data to a file descriptor.
+func fdatasync(db *DB) error { return db.file.Sync() }
+
+// mmap emulates memory-mapping by reading the file region into a slice.
+func mmap(db *DB, sz int) error {
+	b := make([]byte, sz)
+	n, err := db.file.ReadAt(b, 0)
+	// A short read is expected: bbolt maps beyond the current end of the
+	// file. Only a real error (with nothing read past it) is fatal.
+	if err != nil && err != io.EOF && n == 0 {
+		return err
+	}
+	db.dataref = b
+	db.data = (*[common.MaxMapSize]byte)(unsafe.Pointer(&b[0]))
+	db.datasz = sz
+	return nil
+}
+
+// munmap releases the emulated mapping.
+func munmap(db *DB) error {
+	db.dataref = nil
+	db.data = nil
+	db.datasz = 0
+	return nil
+}

--- a/bolt_unix.go
+++ b/bolt_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows && !plan9 && !solaris && !aix && !android
+//go:build !windows && !plan9 && !solaris && !aix && !android && !js
 
 package bbolt
 

--- a/boltsync_unix.go
+++ b/boltsync_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows && !plan9 && !linux && !openbsd
+//go:build !windows && !plan9 && !linux && !openbsd && !js
 
 package bbolt
 

--- a/internal/common/bolt_wasm.go
+++ b/internal/common/bolt_wasm.go
@@ -1,0 +1,9 @@
+package common
+
+// GOARCH=wasm: linear memory is a 32-bit-style address space; mirror the 386 bounds.
+
+// MaxMapSize represents the largest mmap size supported by Bolt.
+const MaxMapSize = 0x7FFFFFFF // 2GB
+
+// MaxAllocSize is the size used when creating array pointers.
+const MaxAllocSize = 0xFFFFFFF

--- a/mlock_js.go
+++ b/mlock_js.go
@@ -1,0 +1,9 @@
+//go:build js
+
+package bbolt
+
+// mlock/munlock are unavailable on js/wasm; locking pages has no meaning in
+// a wasm linear memory.
+func mlock(_ *DB, _ int) error { return nil }
+
+func munlock(_ *DB, _ int) error { return nil }

--- a/mlock_unix.go
+++ b/mlock_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !js
 
 package bbolt
 


### PR DESCRIPTION
Adds the OS layer for the js/wasm target so bbolt compiles for browser and js-runtime builds: no-op flock/mlock (a wasm instance is single-process by construction), mmap emulated as a read of the mapped region into a byte slice (compatible with bbolt's remap-on-grow usage), fdatasync via file.Sync, and GOARCH=wasm address-space bounds mirroring 386. The unix-tagged files gain `!js`.

Under Node the Go runtime's fs shim passes through to the real filesystem and databases open and work normally; in a browser the embedding page decides what filesystem to provide. Motivation: embedding Go applications that use bbolt into browser (wasm) builds — this is running in skycoin/skywire's wasm build. Native builds are unaffected; the native test suite passes.